### PR TITLE
Null Context fixes

### DIFF
--- a/android/src/com/mapswithme/maps/DownloadResourcesLegacyActivity.java
+++ b/android/src/com/mapswithme/maps/DownloadResourcesLegacyActivity.java
@@ -266,7 +266,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity imp
   private void setDownloadMessage(int bytesToDownload)
   {
     mTvMessage.setText(getString(R.string.download_resources,
-                                 StringUtils.getFileSizeString(this, bytesToDownload)));
+                                 StringUtils.getFileSizeString(bytesToDownload)));
   }
 
   private boolean prepareFilesDownload(boolean showMap)
@@ -461,7 +461,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity imp
     if (intent == null)
       return null;
 
-    MwmApplication application = MwmApplication.from(this);
+    MwmApplication application = MwmApplication.get();
     intent.putExtra(Factory.EXTRA_IS_FIRST_LAUNCH, application.isFirstLaunch());
     if (intent.getData() == null)
     {

--- a/android/src/com/mapswithme/maps/MapFragment.java
+++ b/android/src/com/mapswithme/maps/MapFragment.java
@@ -200,7 +200,7 @@ public class MapFragment extends BaseMwmFragment
     requireActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
     final float exactDensityDpi = metrics.densityDpi;
 
-    final boolean firstStart = MwmApplication.from(requireActivity()).isFirstLaunch();
+    final boolean firstStart = MwmApplication.get().isFirstLaunch();
     if (!nativeCreateEngine(surface, (int) exactDensityDpi, firstStart, mLaunchByDeepLink,
                             BuildConfig.VERSION_CODE))
     {

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -490,8 +490,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     // TODO(yunikkk) think about refactoring. It probably should be called in editor.
     Editor.nativeStartEdit();
-    Statistics.INSTANCE.trackEditorLaunch(false,
-                                          String.valueOf(OsmOAuth.isAuthorized(getApplicationContext())));
+    Statistics.INSTANCE.trackEditorLaunch(false, String.valueOf(OsmOAuth.isAuthorized()));
     if (mIsTabletLayout)
       replaceFragment(EditorHostFragment.class, null, null);
     else
@@ -598,7 +597,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     SearchEngine.INSTANCE.addListener(this);
 
-    SharingHelper.INSTANCE.initialize(this);
+    SharingHelper.INSTANCE.initialize(null);
 
     initControllersAndValidatePurchases(savedInstanceState);
 
@@ -606,7 +605,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     // If the map activity is launched by any incoming intent (deeplink, update maps event, etc)
     // or it's the first launch (onboarding) we haven't to try restoring the route,
     // showing the tips, etc.
-    if (isConsumed || MwmApplication.from(this).isFirstLaunch())
+    if (isConsumed || MwmApplication.get().isFirstLaunch())
       return;
 
     if (savedInstanceState == null && RoutingController.get().hasSavedRoute())
@@ -758,8 +757,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mPositionChooser.findViewById(R.id.done).setOnClickListener(
         v ->
         {
-          Statistics.INSTANCE.trackEditorLaunch(true,
-                                                String.valueOf(OsmOAuth.isAuthorized(getApplicationContext())));
+          Statistics.INSTANCE.trackEditorLaunch(true, String.valueOf(OsmOAuth.isAuthorized()));
           hidePositionChooser();
           if (Framework.nativeIsDownloadedMapAtScreenCenter())
             startActivity(new Intent(MwmActivity.this, FeatureCategoryActivity.class));
@@ -1484,10 +1482,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     Context context = getApplicationContext();
 
-    if (!LikesManager.INSTANCE.isNewUser(context) && Counters.isShowReviewForOldUser(context))
+    if (!LikesManager.INSTANCE.isNewUser() && Counters.isShowReviewForOldUser())
     {
       LikesManager.INSTANCE.showRateDialogForOldUser(this);
-      Counters.setShowReviewForOldUser(context, false);
+      Counters.setShowReviewForOldUser(false);
     }
   }
 
@@ -1516,7 +1514,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       LocationHelper.INSTANCE.attach(this);
     mPlacePageController.onActivityStarted(this);
     mSearchController.attach(this);
-    MwmApplication.backgroundTracker(getActivity()).addListener(this);
+    MwmApplication.backgroundTracker().addListener(this);
   }
 
   @Override
@@ -1529,7 +1527,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     LocationHelper.INSTANCE.detach(!isFinishing());
     RoutingController.get().detach();
     mPlacePageController.onActivityStopped(this);
-    MwmApplication.backgroundTracker(getActivity()).removeListener(this);
+    MwmApplication.backgroundTracker().removeListener(this);
     IsolinesManager.from(getApplicationContext()).detach();
     GuidesManager.from(getApplicationContext()).detach();
     mSearchController.detach();
@@ -1741,7 +1739,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
           return;
 
         request.setPointData(object.getLat(), object.getLon(), object.getTitle(), object.getApiId());
-        object.setSubtitle(request.getCallerName(MwmApplication.from(this)).toString());
+        object.setSubtitle(request.getCallerName(MwmApplication.get()).toString());
       }
     }
 
@@ -2895,7 +2893,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     @Override
     public final void onMenuItemClick()
     {
-      Tutorial api = Tutorial.requestCurrent(getActivity(), getActivity().getClass());
+      Tutorial api = Tutorial.requestCurrent(getActivity().getClass());
       LOGGER.d(TAG, "Tutorial = " + api);
       if (getItem() == api.getSiblingMenuItem())
       {
@@ -3026,7 +3024,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     public void onMenuOpen()
     {
       mFadeView.fadeIn();
-      if (!SharedPropertiesUtils.shouldShowLayerTutorialToast(getApplicationContext()))
+      if (!SharedPropertiesUtils.shouldShowLayerTutorialToast())
         return;
 
       UiUtils.showToastAtTop(getApplicationContext(), R.string.routes_layer_in_menu_toast);

--- a/android/src/com/mapswithme/maps/SplashActivity.java
+++ b/android/src/com/mapswithme/maps/SplashActivity.java
@@ -110,7 +110,7 @@ public class SplashActivity extends AppCompatActivity
         return;
       }
 
-      ExternalLibrariesMediator mediator = MwmApplication.from(getApplicationContext()).getMediator();
+      ExternalLibrariesMediator mediator = MwmApplication.get().getMediator();
       if (!mediator.isAdvertisingInfoObtained())
       {
         LOGGER.i(TAG, "Advertising info not obtained yet, wait...");
@@ -187,7 +187,7 @@ public class SplashActivity extends AppCompatActivity
     UiThread.cancelDelayedTasks(mPermissionsDelayedTask);
     UiThread.cancelDelayedTasks(mInitCoreDelayedTask);
     UiThread.cancelDelayedTasks(mFinalDelayedTask);
-    Counters.initCounters(this);
+    Counters.initCounters();
     initView();
   }
 
@@ -236,7 +236,7 @@ public class SplashActivity extends AppCompatActivity
       // If external permissions are still granted we just need to check platform
       // and core initialization, because we may be in the recovering process,
       // i.e. method onResume() may not be invoked in that case.
-      if (!MwmApplication.from(getApplicationContext()).arePlatformAndCoreInitialized())
+      if (!MwmApplication.get().arePlatformAndCoreInitialized())
       {
         init();
       }
@@ -249,7 +249,7 @@ public class SplashActivity extends AppCompatActivity
     super.onStart();
     mBaseDelegate.onStart();
     mAdvertisingObserver.attach(this);
-    ExternalLibrariesMediator mediator = MwmApplication.from(this).getMediator();
+    ExternalLibrariesMediator mediator = MwmApplication.get().getMediator();
     LOGGER.d(TAG, "Add advertising observer");
     mediator.addAdvertisingObserver(mAdvertisingObserver);
   }
@@ -261,16 +261,15 @@ public class SplashActivity extends AppCompatActivity
     mBaseDelegate.onResume();
     mCanceled = false;
 
-    Context context = getApplicationContext();
-    if (Counters.isMigrationNeeded(context))
+    if (Counters.isMigrationNeeded())
     {
-      Config.migrateCountersToSharedPrefs(context);
-      Counters.setMigrationExecuted(context);
+      Config.migrateCountersToSharedPrefs();
+      Counters.setMigrationExecuted();
     }
     
     final boolean isFirstLaunch = WelcomeDialogFragment.isFirstLaunch(this);
     if (isFirstLaunch)
-      MwmApplication.from(this).setFirstLaunch(true);
+      MwmApplication.get().setFirstLaunch(true);
 
     boolean isWelcomeFragmentOnScreen = false;
     DialogFragment welcomeFragment = WelcomeDialogFragment.find(this);
@@ -282,7 +281,7 @@ public class SplashActivity extends AppCompatActivity
 
     if (isFirstLaunch || isWelcomeFragmentOnScreen)
     {
-      if (WelcomeDialogFragment.isAgreementDeclined(this))
+      if (WelcomeDialogFragment.isAgreementDeclined())
       {
         UiThread.runLater(mUserAgreementDelayedTask, FIRST_START_DELAY);
         return;
@@ -356,7 +355,7 @@ public class SplashActivity extends AppCompatActivity
     super.onStop();
     mBaseDelegate.onStop();
     mAdvertisingObserver.detach();
-    ExternalLibrariesMediator mediator = MwmApplication.from(this).getMediator();
+    ExternalLibrariesMediator mediator = MwmApplication.get().getMediator();
     LOGGER.d(TAG, "Remove advertising observer");
     mediator.removeAdvertisingObserver(mAdvertisingObserver);
   }
@@ -391,7 +390,7 @@ public class SplashActivity extends AppCompatActivity
     boolean showNews = NewsFragment.showOn(this, this);
     if (!showNews)
     {
-      if (ViralFragment.shouldDisplay(getApplicationContext()))
+      if (ViralFragment.shouldDisplay())
       {
         UiUtils.hide(mIvLogo, mAppName);
         ViralFragment dialog = new ViralFragment();
@@ -498,7 +497,7 @@ public class SplashActivity extends AppCompatActivity
 
   private void init()
   {
-    MwmApplication app = MwmApplication.from(this);
+    MwmApplication app = MwmApplication.get();
     boolean success = app.initCore();
     if (!success || !app.isFirstLaunch())
       return;

--- a/android/src/com/mapswithme/maps/ads/LikesManager.java
+++ b/android/src/com/mapswithme/maps/ads/LikesManager.java
@@ -5,7 +5,6 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
-import android.content.Context;
 
 import com.mapswithme.maps.BuildConfig;
 import com.mapswithme.maps.MwmActivity;
@@ -58,19 +57,18 @@ public enum LikesManager
   private Runnable mLikeRunnable;
   private WeakReference<FragmentActivity> mActivityRef;
 
-  public boolean isNewUser(@NonNull Context context)
+  public boolean isNewUser()
   {
-    return (Counters.getFirstInstallVersion(context) == BuildConfig.VERSION_CODE);
+    return (Counters.getFirstInstallVersion() == BuildConfig.VERSION_CODE);
   }
 
   public void showRateDialogForOldUser(FragmentActivity activity)
   {
-    Context context = activity.getApplicationContext();
-    if (isNewUser(context))
+    if (isNewUser())
       return;
 
     mActivityRef = new WeakReference<>(activity);
-    displayLikeDialog(context, LikeType.GPLAY_OLD_USERS.clazz, LikeType.GPLAY_OLD_USERS.delay);
+    displayLikeDialog(LikeType.GPLAY_OLD_USERS.clazz, LikeType.GPLAY_OLD_USERS.delay);
   }
 
   public void cancelDialogs()
@@ -89,16 +87,15 @@ public enum LikesManager
     return false;
   }
 
-  private void displayLikeDialog(@NonNull Context context,
-                                 final Class<? extends DialogFragment> dialogFragmentClass,
+  private void displayLikeDialog(final Class<? extends DialogFragment> dialogFragmentClass,
                                  final int delayMillis)
   {
-    int sessionCount = Counters.getSessionCount(context);
-    if (Counters.isSessionRated(context, sessionCount) ||
-        Counters.isRatingApplied(context, dialogFragmentClass))
+    int sessionCount = Counters.getSessionCount();
+    if (Counters.isSessionRated(sessionCount) ||
+        Counters.isRatingApplied(dialogFragmentClass))
       return;
 
-    Counters.setRatedSession(context, sessionCount);
+    Counters.setRatedSession(sessionCount);
 
     UiThread.cancelDelayedTasks(mLikeRunnable);
     mLikeRunnable = new Runnable()

--- a/android/src/com/mapswithme/maps/ads/RateStoreDialogFragment.java
+++ b/android/src/com/mapswithme/maps/ads/RateStoreDialogFragment.java
@@ -64,7 +64,7 @@ public class RateStoreDialogFragment extends BaseMwmDialogFragment implements Vi
         mRating = rating;
         if (rating >= BuildConfig.RATING_THRESHOLD)
         {
-          Counters.setRatingApplied(requireContext(), RateStoreDialogFragment.class);
+          Counters.setRatingApplied(RateStoreDialogFragment.class);
           dismiss();
           Utils.openAppInMarket(getActivity(), BuildConfig.REVIEW_URL);
         }
@@ -115,7 +115,7 @@ public class RateStoreDialogFragment extends BaseMwmDialogFragment implements Vi
       long installTime = 0;
       try
       {
-        info = MwmApplication.from(requireContext())
+        info = MwmApplication.get()
                              .getPackageManager()
                              .getPackageInfo(BuildConfig.APPLICATION_ID, 0);
         installTime = info.firstInstallTime;

--- a/android/src/com/mapswithme/maps/analytics/ExternalLibrariesMediator.java
+++ b/android/src/com/mapswithme/maps/analytics/ExternalLibrariesMediator.java
@@ -95,7 +95,7 @@ public class ExternalLibrariesMediator
   public boolean isCrashlyticsEnabled()
   {
     String prefKey = mApplication.getResources().getString(R.string.pref_opt_out_fabric_activated);
-    return MwmApplication.prefs(mApplication).getBoolean(prefKey, true);
+    return MwmApplication.prefs().getBoolean(prefKey, true);
   }
 
   @NonNull

--- a/android/src/com/mapswithme/maps/background/AbstractLogBroadcastReceiver.java
+++ b/android/src/com/mapswithme/maps/background/AbstractLogBroadcastReceiver.java
@@ -29,7 +29,7 @@ public abstract class AbstractLogBroadcastReceiver extends BroadcastReceiver
     }
 
     String msg = "onReceive: " + intent + " app in background = "
-                 + !backgroundTracker(context).isForeground();
+                 + !backgroundTracker().isForeground();
     LOGGER.i(getTag(), msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, getTag(), msg);
     onReceiveInternal(context, intent);

--- a/android/src/com/mapswithme/maps/background/AppBackgroundTracker.java
+++ b/android/src/com/mapswithme/maps/background/AppBackgroundTracker.java
@@ -2,13 +2,11 @@ package com.mapswithme.maps.background;
 
 import android.app.Activity;
 import android.app.Application;
-import android.content.Context;
 import android.os.Bundle;
 import android.util.SparseArray;
 
 import java.lang.ref.WeakReference;
 
-import androidx.annotation.NonNull;
 import com.mapswithme.maps.MwmApplication;
 import com.mapswithme.util.Listeners;
 import com.mapswithme.util.concurrency.UiThread;
@@ -122,9 +120,9 @@ public final class AppBackgroundTracker
     void onVisibleAppLaunch();
   }
 
-  public AppBackgroundTracker(@NonNull Context context)
+  public AppBackgroundTracker()
   {
-    MwmApplication.from(context).registerActivityLifecycleCallbacks(mAppLifecycleCallbacks);
+    MwmApplication.get().registerActivityLifecycleCallbacks(mAppLifecycleCallbacks);
   }
 
   public boolean isForeground()

--- a/android/src/com/mapswithme/maps/background/NotificationService.java
+++ b/android/src/com/mapswithme/maps/background/NotificationService.java
@@ -52,16 +52,15 @@ public class NotificationService extends JobIntentService
       return false;
     }
 
-    final long lastEventTimestamp = prefs(this)
-        .getLong(LAST_AUTH_NOTIFICATION_TIMESTAMP, 0);
+    final long lastEventTimestamp = prefs().getLong(LAST_AUTH_NOTIFICATION_TIMESTAMP, 0);
 
     if (System.currentTimeMillis() - lastEventTimestamp > MIN_AUTH_EVENT_DELTA_MILLIS)
     {
       LOGGER.d(TAG, "Authentication notification will be sent.");
 
-      prefs(this).edit()
-                                    .putLong(LAST_AUTH_NOTIFICATION_TIMESTAMP, System.currentTimeMillis())
-                                    .apply();
+      prefs().edit()
+              .putLong(LAST_AUTH_NOTIFICATION_TIMESTAMP, System.currentTimeMillis())
+              .apply();
 
       Notifier notifier = Notifier.from(getApplication());
       notifier.notifyAuthentication();
@@ -75,7 +74,7 @@ public class NotificationService extends JobIntentService
 
   private boolean notifySmart()
   {
-    if (MwmApplication.backgroundTracker(getApplication()).isForeground())
+    if (MwmApplication.backgroundTracker().isForeground())
       return false;
 
     NotificationCandidate candidate = LightFramework.nativeGetNotification();
@@ -111,14 +110,14 @@ public class NotificationService extends JobIntentService
     }
 
     // Do not show push when user is in the navigation mode.
-    if (MwmApplication.from(this).arePlatformAndCoreInitialized()
+    if (MwmApplication.get().arePlatformAndCoreInitialized()
         && RoutingController.get().isNavigating())
     {
       LOGGER.d(TAG, "Notification is rejected. The user is in navigation mode.");
       return;
     }
 
-    final NotificationExecutor notifyOrder[] =
+    final NotificationExecutor[] notifyOrder =
     {
       this::notifyIsNotAuthenticated,
       this::notifySmart

--- a/android/src/com/mapswithme/maps/background/UpgradeReceiver.java
+++ b/android/src/com/mapswithme/maps/background/UpgradeReceiver.java
@@ -20,9 +20,9 @@ public class UpgradeReceiver extends BroadcastReceiver
   public void onReceive(Context context, Intent intent)
   {
     String msg = "onReceive: " + intent + " app in background = "
-                 + !backgroundTracker(context).isForeground();
+                 + !backgroundTracker().isForeground();
     LOGGER.i(TAG, msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, TAG, msg);
-    MwmApplication.onUpgrade(context);
+    MwmApplication.onUpgrade();
   }
 }

--- a/android/src/com/mapswithme/maps/background/WorkerService.java
+++ b/android/src/com/mapswithme/maps/background/WorkerService.java
@@ -49,7 +49,7 @@ public class WorkerService extends JobIntentService
   {
     final Context context = getApplicationContext();
     String msg = "onHandleIntent: " + intent + " app in background = "
-                 + !MwmApplication.backgroundTracker(context).isForeground();
+                 + !MwmApplication.backgroundTracker().isForeground();
     LOGGER.i(TAG, msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, TAG, msg);
     final String action = intent.getAction();
@@ -57,7 +57,7 @@ public class WorkerService extends JobIntentService
     if (TextUtils.isEmpty(action))
       return;
 
-    if (!MwmApplication.from(context).arePlatformAndCoreInitialized())
+    if (!MwmApplication.get().arePlatformAndCoreInitialized())
       return;
 
     switch (action)

--- a/android/src/com/mapswithme/maps/base/BaseMwmFragment.java
+++ b/android/src/com/mapswithme/maps/base/BaseMwmFragment.java
@@ -13,7 +13,7 @@ public class BaseMwmFragment extends Fragment implements OnBackPressListener
   public void onAttach(Context context)
   {
     super.onAttach(context);
-    Utils.detachFragmentIfCoreNotInitialized(context, this);
+    Utils.detachFragmentIfCoreNotInitialized(this);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/base/BaseMwmFragmentActivity.java
+++ b/android/src/com/mapswithme/maps/base/BaseMwmFragmentActivity.java
@@ -73,7 +73,7 @@ public abstract class BaseMwmFragmentActivity extends AppCompatActivity
     if (initialIntent != null)
       setIntent(initialIntent);
 
-    if (!MwmApplication.from(this).arePlatformAndCoreInitialized()
+    if (!MwmApplication.get().arePlatformAndCoreInitialized()
         || !PermissionsUtils.isExternalStorageGranted(getApplicationContext()))
     {
       super.onCreate(savedInstanceState);

--- a/android/src/com/mapswithme/maps/base/BaseMwmListFragment.java
+++ b/android/src/com/mapswithme/maps/base/BaseMwmListFragment.java
@@ -19,7 +19,7 @@ public abstract class BaseMwmListFragment extends ListFragment
   public void onAttach(Context context)
   {
     super.onAttach(context);
-    Utils.detachFragmentIfCoreNotInitialized(context, this);
+    Utils.detachFragmentIfCoreNotInitialized(this);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/base/BaseMwmRecyclerFragment.java
+++ b/android/src/com/mapswithme/maps/base/BaseMwmRecyclerFragment.java
@@ -57,7 +57,7 @@ public abstract class BaseMwmRecyclerFragment<T extends RecyclerView.Adapter> ex
   public void onAttach(Context context)
   {
     super.onAttach(context);
-    Utils.detachFragmentIfCoreNotInitialized(context, this);
+    Utils.detachFragmentIfCoreNotInitialized(this);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkBackupController.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkBackupController.java
@@ -200,7 +200,7 @@ public class BookmarkBackupController implements Authorizer.Callback,
   {
     mAuthorizer.attach(this);
     BookmarkManager.INSTANCE.addCloudListener(this);
-    mBackupView.setExpanded(SharedPropertiesUtils.getBackupWidgetExpanded(mContext));
+    mBackupView.setExpanded(SharedPropertiesUtils.getBackupWidgetExpanded());
     updateWidget();
   }
 
@@ -208,7 +208,7 @@ public class BookmarkBackupController implements Authorizer.Callback,
   {
     mAuthorizer.detach();
     BookmarkManager.INSTANCE.removeCloudListener(this);
-    SharedPropertiesUtils.setBackupWidgetExpanded(mContext, mBackupView.getExpanded());
+    SharedPropertiesUtils.setBackupWidgetExpanded(mBackupView.getExpanded());
   }
 
   public void onTargetFragmentResult(int resultCode, @Nullable Intent data)

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesActivity.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesActivity.java
@@ -88,13 +88,13 @@ public class BookmarkCategoriesActivity extends BaseToolbarActivity
 
   public static void startForResult(@NonNull Activity context)
   {
-    int initialPage = SharedPropertiesUtils.getLastVisibleBookmarkCategoriesPage(context);
+    int initialPage = SharedPropertiesUtils.getLastVisibleBookmarkCategoriesPage();
     startForResult(context, initialPage, null, null);
   }
 
   public static void startForResult(@NonNull Activity context, @Nullable BookmarkCategory category)
   {
-    int initialPage = SharedPropertiesUtils.getLastVisibleBookmarkCategoriesPage(context);
+    int initialPage = SharedPropertiesUtils.getLastVisibleBookmarkCategoriesPage();
     startForResult(context, initialPage, null, category);
   }
 }

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesPagerFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesPagerFragment.java
@@ -24,7 +24,6 @@ import com.mapswithme.util.SharedPropertiesUtils;
 import com.mapswithme.util.statistics.Statistics;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class BookmarkCategoriesPagerFragment extends BaseMwmFragment
@@ -175,11 +174,11 @@ public class BookmarkCategoriesPagerFragment extends BaseMwmFragment
     if (args != null && args.containsKey(ARG_CATEGORIES_PAGE))
     {
       int page = args.getInt(ARG_CATEGORIES_PAGE);
-      SharedPropertiesUtils.setLastVisibleBookmarkCategoriesPage(requireActivity(), page);
+      SharedPropertiesUtils.setLastVisibleBookmarkCategoriesPage(page);
       return page;
     }
 
-    return SharedPropertiesUtils.getLastVisibleBookmarkCategoriesPage(requireActivity());
+    return SharedPropertiesUtils.getLastVisibleBookmarkCategoriesPage();
   }
 
   @NonNull
@@ -262,7 +261,7 @@ public class BookmarkCategoriesPagerFragment extends BaseMwmFragment
     @Override
     public void onPageSelected(int position)
     {
-      SharedPropertiesUtils.setLastVisibleBookmarkCategoriesPage(requireActivity(), position);
+      SharedPropertiesUtils.setLastVisibleBookmarkCategoriesPage(position);
       BookmarksPageFactory factory = mAdapter.getItemFactory(position);
       Statistics.INSTANCE.trackBookmarksTabEvent(factory.getAnalytics().getName());
     }

--- a/android/src/com/mapswithme/maps/bookmarks/CachedBookmarkCategoriesFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/CachedBookmarkCategoriesFragment.java
@@ -58,7 +58,7 @@ public class CachedBookmarkCategoriesFragment extends BaseBookmarkCategoriesFrag
     downloadRoutesBtn.setOnClickListener(btn -> openBookmarksCatalogScreen());
     View closeHeaderBtn = view.findViewById(R.id.header_close);
     closeHeaderBtn.setOnClickListener(new CloseHeaderClickListener());
-    boolean isClosed = SharedPropertiesUtils.isCatalogCategoriesHeaderClosed(requireContext());
+    boolean isClosed = SharedPropertiesUtils.isCatalogCategoriesHeaderClosed();
     View header = view.findViewById(R.id.header);
     UiUtils.hideIf(isClosed, header);
     ImageView imageView = downloadRoutesBtn.findViewById(R.id.image);
@@ -181,7 +181,7 @@ public class CachedBookmarkCategoriesFragment extends BaseBookmarkCategoriesFrag
     {
       View header = mPayloadContainer.findViewById(R.id.header);
       header.setVisibility(View.GONE);
-      SharedPropertiesUtils.setCatalogCategoriesHeaderClosed(requireContext(), true);
+      SharedPropertiesUtils.setCatalogCategoriesHeaderClosed(true);
     }
   }
 

--- a/android/src/com/mapswithme/maps/discovery/DiscoveryFragment.java
+++ b/android/src/com/mapswithme/maps/discovery/DiscoveryFragment.java
@@ -195,9 +195,9 @@ public class DiscoveryFragment extends BaseMwmToolbarFragment implements Discove
   private void initSearchBasedAdapters()
   {
     Context context = requireContext();
-    getGallery(R.id.hotels).setAdapter(Factory.createSearchBasedLoadingAdapter(context));
-    getGallery(R.id.attractions).setAdapter(Factory.createSearchBasedLoadingAdapter(context));
-    getGallery(R.id.food).setAdapter(Factory.createSearchBasedLoadingAdapter(context));
+    getGallery(R.id.hotels).setAdapter(Factory.createSearchBasedLoadingAdapter());
+    getGallery(R.id.attractions).setAdapter(Factory.createSearchBasedLoadingAdapter());
+    getGallery(R.id.food).setAdapter(Factory.createSearchBasedLoadingAdapter());
   }
 
   private void initNetworkBasedAdapters()
@@ -209,8 +209,8 @@ public class DiscoveryFragment extends BaseMwmToolbarFragment implements Discove
                                                 : new ErrorCatalogPromoListener<>(requireActivity(),
                                                                                   this::onNetworkPolicyResult);
 
-    GalleryAdapter adapter = mOnlineMode ? Factory.createCatalogPromoLoadingAdapter(requireContext())
-                                         : Factory.createCatalogPromoErrorAdapter(requireContext(), listener);
+    GalleryAdapter adapter = mOnlineMode ? Factory.createCatalogPromoLoadingAdapter()
+                                         : Factory.createCatalogPromoErrorAdapter(listener);
     promoRecycler.setAdapter(adapter);
   }
 
@@ -311,24 +311,25 @@ public class DiscoveryFragment extends BaseMwmToolbarFragment implements Discove
     switch (type)
     {
       case HOTELS:
-        getGallery(R.id.hotels).setAdapter(Factory.createSearchBasedErrorAdapter(requireContext()));
+        getGallery(R.id.hotels).setAdapter(Factory.createSearchBasedErrorAdapter());
         Statistics.INSTANCE.trackGalleryError(SEARCH_HOTELS, DISCOVERY, null);
         break;
       case ATTRACTIONS:
-        getGallery(R.id.attractions).setAdapter(Factory.createSearchBasedErrorAdapter(requireContext()));
+        getGallery(R.id.attractions).setAdapter(Factory.createSearchBasedErrorAdapter());
         Statistics.INSTANCE.trackGalleryError(SEARCH_ATTRACTIONS, DISCOVERY, null);
         break;
       case CAFES:
-        getGallery(R.id.food).setAdapter(Factory.createSearchBasedErrorAdapter(requireContext()));
+        getGallery(R.id.food).setAdapter(Factory.createSearchBasedErrorAdapter());
         Statistics.INSTANCE.trackGalleryError(SEARCH_RESTAURANTS, DISCOVERY, null);
         break;
       case LOCAL_EXPERTS:
-        getGallery(R.id.localGuides).setAdapter(Factory.createLocalExpertsErrorAdapter(requireContext()));
+        getGallery(R.id.localGuides).setAdapter(Factory.createLocalExpertsErrorAdapter());
         Statistics.INSTANCE.trackGalleryError(LOCAL_EXPERTS, DISCOVERY, null);
         break;
       case PROMO:
-        GalleryAdapter adapter = Factory.createCatalogPromoErrorAdapter(requireContext(),
-            new ErrorCatalogPromoListener<>(requireActivity(), this::onNetworkPolicyResult));
+        GalleryAdapter adapter = Factory.createCatalogPromoErrorAdapter(
+            new ErrorCatalogPromoListener<>(requireActivity(), this::onNetworkPolicyResult)
+        );
         RecyclerView gallery = getGallery(R.id.catalog_promo_recycler);
         gallery.setAdapter(adapter);
         Statistics.INSTANCE.trackGalleryError(PROMO, DISCOVERY, null);

--- a/android/src/com/mapswithme/maps/downloader/BottomPanel.java
+++ b/android/src/com/mapswithme/maps/downloader/BottomPanel.java
@@ -97,7 +97,7 @@ class BottomPanel
   private void setUpdateAllState(UpdateInfo info)
   {
     mButton.setText(String.format(Locale.US, "%s (%s)", mFragment.getString(R.string.downloader_update_all_button),
-                                  StringUtils.getFileSizeString(mFragment.requireContext(), info.totalSize)));
+                                  StringUtils.getFileSizeString(info.totalSize)));
     mButton.setOnClickListener(mUpdateListener);
   }
 

--- a/android/src/com/mapswithme/maps/downloader/CountrySuggestFragment.java
+++ b/android/src/com/mapswithme/maps/downloader/CountrySuggestFragment.java
@@ -139,7 +139,7 @@ public class CountrySuggestFragment extends BaseMwmFragment implements View.OnCl
 
     mBtnDownloadMap.setText(String.format(Locale.US, "%1$s (%2$s)",
                                           getString(R.string.downloader_download_map),
-                                          StringUtils.getFileSizeString(requireContext(), mCurrentCountry.totalSize)));
+                                          StringUtils.getFileSizeString(mCurrentCountry.totalSize)));
   }
 
   private void initViews(View view)

--- a/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
+++ b/android/src/com/mapswithme/maps/downloader/DownloaderAdapter.java
@@ -613,7 +613,7 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
         size = ((!mSearchResultsMode && mMyMapsMode) ? mItem.size : mItem.totalSize);
       }
 
-      mSize.setText(StringUtils.getFileSizeString(mFragment.requireContext(), size));
+      mSize.setText(StringUtils.getFileSizeString(size));
       mStatusIcon.update(mItem);
     }
   }
@@ -1066,7 +1066,7 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
           }
         }, mActivity);
       }
-    }, mActivity.getApplicationContext());
+    });
   }
 
   private void clearAdsInternal()

--- a/android/src/com/mapswithme/maps/downloader/OnmapDownloader.java
+++ b/android/src/com/mapswithme/maps/downloader/OnmapDownloader.java
@@ -166,7 +166,7 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
           }
           else
           {
-            sizeText = StringUtils.getFileSizeString(mActivity.getApplicationContext(), mCurrentCountry.totalSize);
+            sizeText = StringUtils.getFileSizeString(mCurrentCountry.totalSize);
 
             if (shouldAutoDownload &&
                 Config.isAutodownloadEnabled() &&

--- a/android/src/com/mapswithme/maps/downloader/UpdaterDialogFragment.java
+++ b/android/src/com/mapswithme/maps/downloader/UpdaterDialogFragment.java
@@ -181,7 +181,7 @@ public class UpdaterDialogFragment extends BaseMwmDialogFragment
 
     final Bundle args = new Bundle();
     args.putBoolean(ARG_UPDATE_IMMEDIATELY, result == Framework.DO_AFTER_UPDATE_AUTO_UPDATE);
-    args.putString(ARG_TOTAL_SIZE, StringUtils.getFileSizeString(activity.getApplicationContext(), info.totalSize));
+    args.putString(ARG_TOTAL_SIZE, StringUtils.getFileSizeString(info.totalSize));
     args.putLong(ARG_TOTAL_SIZE_BYTES, info.totalSize);
     args.putStringArray(ARG_OUTDATED_MAPS, Framework.nativeGetOutdatedCountries());
 
@@ -379,7 +379,7 @@ public class UpdaterDialogFragment extends BaseMwmDialogFragment
   {
     return getString(R.string.downloader_percent, progress + "%",
                      localSize / Constants.MB + getString(R.string.mb),
-                     StringUtils.getFileSizeString(requireContext(), remoteSize));
+                     StringUtils.getFileSizeString(remoteSize));
   }
 
   void setProgress(int progress, long localSize, long remoteSize)
@@ -405,7 +405,7 @@ public class UpdaterDialogFragment extends BaseMwmDialogFragment
 
   void updateTotalSizes(long totalSize)
   {
-    mTotalSize = StringUtils.getFileSizeString(requireContext(), totalSize);
+    mTotalSize = StringUtils.getFileSizeString(totalSize);
     mTotalSizeBytes = totalSize;
   }
 

--- a/android/src/com/mapswithme/maps/editor/Editor.java
+++ b/android/src/com/mapswithme/maps/editor/Editor.java
@@ -48,14 +48,14 @@ public final class Editor
 
   public static void init(@NonNull Context context)
   {
-    MwmApplication.backgroundTracker(context).addListener(new OsmUploadListener(context));
+    MwmApplication.backgroundTracker().addListener(new OsmUploadListener(context));
   }
 
   @WorkerThread
   public static void uploadChanges(@NonNull Context context)
   {
-    if (nativeHasSomethingToUpload() && OsmOAuth.isAuthorized(context))
-      nativeUploadChanges(OsmOAuth.getAuthToken(context), OsmOAuth.getAuthSecret(context),
+    if (nativeHasSomethingToUpload() && OsmOAuth.isAuthorized())
+      nativeUploadChanges(OsmOAuth.getAuthToken(), OsmOAuth.getAuthSecret(),
                           BuildConfig.VERSION_NAME, BuildConfig.APPLICATION_ID);
   }
 

--- a/android/src/com/mapswithme/maps/editor/EditorFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorFragment.java
@@ -347,8 +347,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     {
       final Timetable[] timetables = OpeningHours.nativeTimetablesFromString(openingHours);
       String content = timetables == null ? openingHours
-                                          : TimeFormatUtils.formatTimetables(requireContext(),
-                                                                             timetables);
+                                          : TimeFormatUtils.formatTimetables(timetables);
       UiUtils.hide(mEmptyOpeningHours);
       UiUtils.setTextAndShow(mOpeningHours, content);
       UiUtils.show(mEditOpeningHours);

--- a/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
@@ -292,7 +292,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
           return;
 
         // Save object edits
-        if (!MwmApplication.prefs(requireContext()).contains(NOOB_ALERT_SHOWN))
+        if (!MwmApplication.prefs().contains(NOOB_ALERT_SHOWN))
         {
           showNoobDialog();
         }
@@ -316,17 +316,15 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
 
   private void processNoFeatures()
   {
-    Statistics.INSTANCE.trackEditorError(mIsNewObject,
-                                         String.valueOf(OsmOAuth.isAuthorized(requireContext())));
+    Statistics.INSTANCE.trackEditorError(mIsNewObject, String.valueOf(OsmOAuth.isAuthorized()));
     DialogUtils.showAlertDialog(getActivity(), R.string.downloader_no_space_title);
   }
 
   private void processEditedFeatures()
   {
     Context context = requireContext();
-    Statistics.INSTANCE.trackEditorSuccess(mIsNewObject,
-                                           String.valueOf(OsmOAuth.isAuthorized(context)));
-    if (OsmOAuth.isAuthorized(context) || !ConnectionState.INSTANCE.isConnected())
+    Statistics.INSTANCE.trackEditorSuccess(mIsNewObject, String.valueOf(OsmOAuth.isAuthorized()));
+    if (OsmOAuth.isAuthorized() || !ConnectionState.INSTANCE.isConnected())
     {
       Utils.navigateToParent(getActivity());
       return;
@@ -389,7 +387,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
         @Override
         public void onClick(DialogInterface dlg, int which)
         {
-          MwmApplication.prefs(requireContext()).edit()
+          MwmApplication.prefs().edit()
                         .putBoolean(NOOB_ALERT_SHOWN, true)
                         .apply();
           saveNote();

--- a/android/src/com/mapswithme/maps/editor/OsmAuthFragmentDelegate.java
+++ b/android/src/com/mapswithme/maps/editor/OsmAuthFragmentDelegate.java
@@ -70,7 +70,7 @@ public abstract class OsmAuthFragmentDelegate implements View.OnClickListener
       return;
     }
 
-    OsmOAuth.setAuthorization(mFragment.requireContext(), auth[0], auth[1], username);
+    OsmOAuth.setAuthorization(auth[0], auth[1], username);
     if (mFragment.isAdded())
       Utils.navigateToParent(mFragment.getActivity());
     Statistics.INSTANCE.trackEvent(Statistics.EventName.EDITOR_AUTH_REQUEST_RESULT,

--- a/android/src/com/mapswithme/maps/editor/OsmOAuth.java
+++ b/android/src/com/mapswithme/maps/editor/OsmOAuth.java
@@ -1,9 +1,7 @@
 package com.mapswithme.maps.editor;
 
-import android.content.Context;
 
 import androidx.annotation.IntDef;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
 import androidx.annotation.WorkerThread;
@@ -73,40 +71,39 @@ public final class OsmOAuth
 
   public static final String URL_PARAM_VERIFIER = "oauth_verifier";
 
-  public static boolean isAuthorized(@NonNull Context context)
+  public static boolean isAuthorized()
   {
-    return MwmApplication.prefs(context).contains(PREF_OSM_TOKEN) &&
-           MwmApplication.prefs(context).contains(PREF_OSM_SECRET);
+    return MwmApplication.prefs().contains(PREF_OSM_TOKEN) &&
+           MwmApplication.prefs().contains(PREF_OSM_SECRET);
   }
 
-  public static String getAuthToken(@NonNull Context context)
+  public static String getAuthToken()
   {
-    return MwmApplication.prefs(context).getString(PREF_OSM_TOKEN, "");
+    return MwmApplication.prefs().getString(PREF_OSM_TOKEN, "");
   }
 
-  public static String getAuthSecret(@NonNull Context context)
+  public static String getAuthSecret()
   {
-    return MwmApplication.prefs(context).getString(PREF_OSM_SECRET, "");
+    return MwmApplication.prefs().getString(PREF_OSM_SECRET, "");
   }
 
-  public static String getUsername(@NonNull Context context)
+  public static String getUsername()
   {
-    return MwmApplication.prefs(context).getString(PREF_OSM_USERNAME, "");
+    return MwmApplication.prefs().getString(PREF_OSM_USERNAME, "");
   }
 
-  public static void setAuthorization(@NonNull Context context, String token,
-                                      String secret, String username)
+  public static void setAuthorization(String token, String secret, String username)
   {
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .putString(PREF_OSM_TOKEN, token)
                   .putString(PREF_OSM_SECRET, secret)
                   .putString(PREF_OSM_USERNAME, username)
                   .apply();
   }
 
-  public static void clearAuthorization(@NonNull Context context)
+  public static void clearAuthorization()
   {
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .remove(PREF_OSM_TOKEN)
                   .remove(PREF_OSM_SECRET)
                   .remove(PREF_OSM_USERNAME)

--- a/android/src/com/mapswithme/maps/editor/ProfileFragment.java
+++ b/android/src/com/mapswithme/maps/editor/ProfileFragment.java
@@ -49,7 +49,7 @@ public class ProfileFragment extends AuthFragment implements View.OnClickListene
               @Override
               public void onClick(DialogInterface dialog, int which)
               {
-                OsmOAuth.clearAuthorization(fragment.requireContext());
+                OsmOAuth.clearAuthorization();
                 fragment.refreshViews();
               }
             })
@@ -64,7 +64,7 @@ public class ProfileFragment extends AuthFragment implements View.OnClickListene
       @Override
       void invoke(ProfileFragment fragment)
       {
-        OsmOAuth.nativeUpdateOsmUserStats(OsmOAuth.getUsername(fragment.requireContext()), true /* forceUpdate */);
+        OsmOAuth.nativeUpdateOsmUserStats(OsmOAuth.getUsername(), true /* forceUpdate */);
       }
     };
 
@@ -88,7 +88,7 @@ public class ProfileFragment extends AuthFragment implements View.OnClickListene
     initViews(view);
     refreshViews();
     OsmOAuth.setUserStatsListener(this);
-    OsmOAuth.nativeUpdateOsmUserStats(OsmOAuth.getUsername(requireContext()), false /* forceUpdate */);
+    OsmOAuth.nativeUpdateOsmUserStats(OsmOAuth.getUsername(), false /* forceUpdate */);
   }
 
   private void initViews(View view)
@@ -110,7 +110,7 @@ public class ProfileFragment extends AuthFragment implements View.OnClickListene
 
   private void refreshViews()
   {
-    if (OsmOAuth.isAuthorized(requireContext()))
+    if (OsmOAuth.isAuthorized())
     {
       UiUtils.show(mMore, mRatingBlock, mSentBlock);
       UiUtils.hide(mAuthBlock);

--- a/android/src/com/mapswithme/maps/editor/StreetAdapter.java
+++ b/android/src/com/mapswithme/maps/editor/StreetAdapter.java
@@ -63,7 +63,7 @@ public class StreetAdapter extends RecyclerView.Adapter<StreetAdapter.BaseViewHo
 
   private void addStreet()
   {
-    final Resources resources = MwmApplication.from(mFragment.requireContext()).getResources();
+    final Resources resources = MwmApplication.get().getResources();
     EditTextDialogFragment.show(resources.getString(R.string.street), null,
                                 resources.getString(R.string.ok),
                                 resources.getString(R.string.cancel), mFragment);

--- a/android/src/com/mapswithme/maps/editor/ViralFragment.java
+++ b/android/src/com/mapswithme/maps/editor/ViralFragment.java
@@ -27,9 +27,9 @@ public class ViralFragment extends BaseMwmDialogFragment
   @Nullable
   private Runnable mDismissListener;
 
-  public static boolean shouldDisplay(@NonNull Context context)
+  public static boolean shouldDisplay()
   {
-    return !MwmApplication.prefs(context).contains(EXTRA_CONGRATS_SHOWN) &&
+    return !MwmApplication.prefs().contains(EXTRA_CONGRATS_SHOWN) &&
            Editor.nativeGetStats()[0] == 2 &&
            ConnectionState.INSTANCE.isConnected();
   }
@@ -44,7 +44,7 @@ public class ViralFragment extends BaseMwmDialogFragment
   @Override
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
   {
-    MwmApplication.prefs(requireContext()).edit().putBoolean(EXTRA_CONGRATS_SHOWN, true).apply();
+    MwmApplication.prefs().edit().putBoolean(EXTRA_CONGRATS_SHOWN, true).apply();
     return inflater.inflate(R.layout.fragment_editor_viral, null);
   }
 

--- a/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
+++ b/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
@@ -1,6 +1,5 @@
 package com.mapswithme.maps.editor.data;
 
-import android.content.Context;
 import android.content.res.Resources;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
@@ -67,9 +66,9 @@ public class TimeFormatUtils
     return builder.toString();
   }
 
-  public static String formatTimetables(@NonNull Context context,  @NonNull Timetable[] timetables)
+  public static String formatTimetables(@NonNull Timetable[] timetables)
   {
-    final Resources resources = MwmApplication.from(context).getResources();
+    final Resources resources = MwmApplication.get().getResources();
 
     if (timetables[0].isFullWeek())
     {

--- a/android/src/com/mapswithme/maps/gallery/SimpleSingleItemAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/SimpleSingleItemAdapterStrategy.java
@@ -1,6 +1,5 @@
 package com.mapswithme.maps.gallery;
 
-import android.content.Context;
 import android.content.res.Resources;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -13,23 +12,21 @@ import com.mapswithme.maps.MwmApplication;
 public abstract class SimpleSingleItemAdapterStrategy<T extends Holders.BaseViewHolder<Items.Item>>
     extends SingleItemAdapterStrategy<T>
 {
-  protected SimpleSingleItemAdapterStrategy(@NonNull Context context,
-                                            @Nullable ItemSelectedListener<Items.Item> listener,
+  protected SimpleSingleItemAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener,
                                             @Nullable String url)
   {
-    super(context, url, listener);
+    super(url, listener);
   }
 
-  protected SimpleSingleItemAdapterStrategy(@NonNull Context context,
-                                            @Nullable ItemSelectedListener<Items.Item> listener)
+  protected SimpleSingleItemAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener)
   {
-    this(context, listener, null);
+    this(listener, null);
   }
 
   @Override
-  protected void buildItem(@NonNull Context context, @Nullable String url)
+  protected void buildItem(@Nullable String url)
   {
-    Resources res = MwmApplication.from(context).getResources();
+    Resources res = MwmApplication.get().getResources();
     mItems.add(new Items.Item(res.getString(getTitle()), null, null));
   }
 

--- a/android/src/com/mapswithme/maps/gallery/SingleItemAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/SingleItemAdapterStrategy.java
@@ -1,6 +1,5 @@
 package com.mapswithme.maps.gallery;
 
-import android.content.Context;
 import android.content.res.Resources;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -16,17 +15,16 @@ import com.mapswithme.maps.R;
 abstract class SingleItemAdapterStrategy<T extends Holders.BaseViewHolder<Items.Item>>
     extends AdapterStrategy<T, Items.Item>
 {
-  SingleItemAdapterStrategy(@NonNull Context context,
-                            @Nullable String url,
+  SingleItemAdapterStrategy(@Nullable String url,
                             @Nullable ItemSelectedListener<Items.Item> listener)
   {
     super(listener);
-    buildItem(context, url);
+    buildItem(url);
   }
 
-  protected void buildItem(@NonNull Context context, @Nullable String url)
+  protected void buildItem(@Nullable String url)
   {
-    Resources res = MwmApplication.from(context).getResources();
+    Resources res = MwmApplication.get().getResources();
     mItems.add(new Items.Item(res.getString(getTitle()), url,
                               res.getString(getSubtitle())));
   }

--- a/android/src/com/mapswithme/maps/gallery/impl/CatalogPromoErrorAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/impl/CatalogPromoErrorAdapterStrategy.java
@@ -3,7 +3,6 @@ package com.mapswithme.maps.gallery.impl;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,9 +14,9 @@ import com.mapswithme.maps.gallery.Items;
 
 class CatalogPromoErrorAdapterStrategy extends SimpleErrorAdapterStrategy
 {
-  CatalogPromoErrorAdapterStrategy(@NonNull Context context, @Nullable ItemSelectedListener<Items.Item> listener)
+  CatalogPromoErrorAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener)
   {
-    super(context, listener);
+    super(listener);
   }
 
   @NonNull

--- a/android/src/com/mapswithme/maps/gallery/impl/CatalogPromoLoadingAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/impl/CatalogPromoLoadingAdapterStrategy.java
@@ -15,11 +15,10 @@ import com.mapswithme.maps.gallery.Items;
 
 class CatalogPromoLoadingAdapterStrategy extends SimpleLoadingAdapterStrategy
 {
-  CatalogPromoLoadingAdapterStrategy(@NonNull Context context,
-                                     @Nullable ItemSelectedListener<Items.Item> listener,
+  CatalogPromoLoadingAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener,
                                      @Nullable String url)
   {
-    super(context, listener, url);
+    super(listener, url);
   }
 
   @NonNull

--- a/android/src/com/mapswithme/maps/gallery/impl/Factory.java
+++ b/android/src/com/mapswithme/maps/gallery/impl/Factory.java
@@ -41,15 +41,15 @@ public class Factory
   }
 
   @NonNull
-  public static GalleryAdapter createSearchBasedLoadingAdapter(@NonNull Context context)
+  public static GalleryAdapter createSearchBasedLoadingAdapter()
   {
-    return new GalleryAdapter<>(new SimpleLoadingAdapterStrategy(context, null));
+    return new GalleryAdapter<>(new SimpleLoadingAdapterStrategy(null));
   }
 
   @NonNull
-  public static GalleryAdapter createSearchBasedErrorAdapter(@NonNull Context context)
+  public static GalleryAdapter createSearchBasedErrorAdapter()
   {
-    return new GalleryAdapter<>(new SimpleErrorAdapterStrategy(context, null));
+    return new GalleryAdapter<>(new SimpleErrorAdapterStrategy( null));
   }
 
   @NonNull
@@ -76,9 +76,9 @@ public class Factory
   }
 
   @NonNull
-  public static GalleryAdapter createLocalExpertsErrorAdapter(@NonNull Context context)
+  public static GalleryAdapter createLocalExpertsErrorAdapter()
   {
-    return new GalleryAdapter<>(new LocalExpertsErrorAdapterStrategy(context, null));
+    return new GalleryAdapter<>(new LocalExpertsErrorAdapterStrategy(null));
   }
 
   @NonNull
@@ -112,17 +112,16 @@ public class Factory
   }
 
   @NonNull
-  public static GalleryAdapter createCatalogPromoLoadingAdapter(@NonNull Context context)
+  public static GalleryAdapter createCatalogPromoLoadingAdapter()
   {
-    CatalogPromoLoadingAdapterStrategy strategy = new CatalogPromoLoadingAdapterStrategy(context, null, null);
+    CatalogPromoLoadingAdapterStrategy strategy = new CatalogPromoLoadingAdapterStrategy(null, null);
     return new GalleryAdapter<>(strategy);
   }
 
   @NonNull
-  public static GalleryAdapter createCatalogPromoErrorAdapter(@NonNull Context context,
-                                                              @Nullable ItemSelectedListener<Items.Item> listener)
+  public static GalleryAdapter createCatalogPromoErrorAdapter(@Nullable ItemSelectedListener<Items.Item> listener)
   {
-    return new GalleryAdapter<>(new CatalogPromoErrorAdapterStrategy(context, listener));
+    return new GalleryAdapter<>(new CatalogPromoErrorAdapterStrategy(listener));
   }
 
   private static <Product> void trackProductGalleryShownOrError(@NonNull Product[] products,

--- a/android/src/com/mapswithme/maps/gallery/impl/LocalExpertsErrorAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/impl/LocalExpertsErrorAdapterStrategy.java
@@ -14,10 +14,9 @@ import com.mapswithme.maps.gallery.Items;
 
 public class LocalExpertsErrorAdapterStrategy extends SimpleErrorAdapterStrategy
 {
-  LocalExpertsErrorAdapterStrategy(@NonNull Context context,
-                                   @Nullable ItemSelectedListener<Items.Item> listener)
+  LocalExpertsErrorAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener)
   {
-    super(context, listener);
+    super(listener);
   }
 
   @NonNull

--- a/android/src/com/mapswithme/maps/gallery/impl/LocalExpertsLoadingAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/impl/LocalExpertsLoadingAdapterStrategy.java
@@ -3,7 +3,6 @@ package com.mapswithme.maps.gallery.impl;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,10 +13,9 @@ import com.mapswithme.maps.gallery.Items;
 
 public class LocalExpertsLoadingAdapterStrategy extends SimpleLoadingAdapterStrategy
 {
-  LocalExpertsLoadingAdapterStrategy(@NonNull Context context,
-                                     @Nullable ItemSelectedListener<Items.Item> listener)
+  LocalExpertsLoadingAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener)
   {
-    super(context, listener);
+    super(listener);
   }
 
   @NonNull

--- a/android/src/com/mapswithme/maps/gallery/impl/SimpleErrorAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/impl/SimpleErrorAdapterStrategy.java
@@ -3,7 +3,6 @@ package com.mapswithme.maps.gallery.impl;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,10 +16,9 @@ import com.mapswithme.maps.gallery.SimpleSingleItemAdapterStrategy;
 public class SimpleErrorAdapterStrategy
     extends SimpleSingleItemAdapterStrategy<Holders.SimpleViewHolder>
 {
-  SimpleErrorAdapterStrategy(@NonNull Context context,
-                             @Nullable ItemSelectedListener<Items.Item> listener)
+  SimpleErrorAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener)
   {
-    super(context, listener);
+    super(listener);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/gallery/impl/SimpleLoadingAdapterStrategy.java
+++ b/android/src/com/mapswithme/maps/gallery/impl/SimpleLoadingAdapterStrategy.java
@@ -3,7 +3,6 @@ package com.mapswithme.maps.gallery.impl;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,17 +16,15 @@ import com.mapswithme.maps.gallery.SimpleSingleItemAdapterStrategy;
 public class SimpleLoadingAdapterStrategy
     extends SimpleSingleItemAdapterStrategy<Holders.SimpleViewHolder>
 {
-  SimpleLoadingAdapterStrategy(@NonNull Context context,
-                               @Nullable ItemSelectedListener<Items.Item> listener)
+  SimpleLoadingAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener)
   {
-    this(context, listener, null);
+    this(listener, null);
   }
 
-  public SimpleLoadingAdapterStrategy(@NonNull Context context,
-                                      @Nullable ItemSelectedListener<Items.Item> listener,
+  public SimpleLoadingAdapterStrategy(@Nullable ItemSelectedListener<Items.Item> listener,
                                       @Nullable String url)
   {
-    super(context, listener, url);
+    super(listener, url);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/intent/Factory.java
+++ b/android/src/com/mapswithme/maps/intent/Factory.java
@@ -1334,7 +1334,7 @@ public class Factory
     @Override
     public boolean run(@NonNull MwmActivity target)
     {
-      Tutorial tutorial = Tutorial.requestCurrent(target, target.getClass());
+      Tutorial tutorial = Tutorial.requestCurrent(target.getClass());
       if (tutorial == Tutorial.STUB)
         return false;
 

--- a/android/src/com/mapswithme/maps/intent/StatisticMapTaskWrapper.java
+++ b/android/src/com/mapswithme/maps/intent/StatisticMapTaskWrapper.java
@@ -20,7 +20,7 @@ public class StatisticMapTaskWrapper implements MapTask
   public boolean run(@NonNull MwmActivity target)
   {
     boolean success = mMapTask.run(target);
-    boolean firstLaunch = MwmApplication.from(target).isFirstLaunch();
+    boolean firstLaunch = MwmApplication.get().isFirstLaunch();
     if (success)
       Statistics.INSTANCE.trackDeeplinkEvent(Statistics.EventName.DEEPLINK_CALL,
                                              mMapTask.toStatisticParams(), firstLaunch);

--- a/android/src/com/mapswithme/maps/location/AndroidNativeProvider.java
+++ b/android/src/com/mapswithme/maps/location/AndroidNativeProvider.java
@@ -29,7 +29,7 @@ class AndroidNativeProvider extends BaseLocationProvider
   {
     super(locationFixChecker);
     Objects.requireNonNull(context, "Context should be passed!");
-    mLocationManager = (LocationManager) MwmApplication.from(context).getSystemService(Context.LOCATION_SERVICE);
+    mLocationManager = (LocationManager) MwmApplication.get().getSystemService(Context.LOCATION_SERVICE);
   }
 
   @SuppressWarnings("MissingPermission")
@@ -94,9 +94,9 @@ class AndroidNativeProvider extends BaseLocationProvider
   }
 
   @Nullable
-  static Location findBestLocation(@NonNull Context context)
+  static Location findBestLocation()
   {
-    final LocationManager manager = (LocationManager) MwmApplication.from(context).getSystemService(Context.LOCATION_SERVICE);
+    final LocationManager manager = (LocationManager) MwmApplication.get().getSystemService(Context.LOCATION_SERVICE);
     return findBestLocation(manager, getAvailableProviders(manager));
   }
 

--- a/android/src/com/mapswithme/maps/location/CompassData.java
+++ b/android/src/com/mapswithme/maps/location/CompassData.java
@@ -12,9 +12,9 @@ public final class CompassData
 {
   private double mNorth;
 
-  public void update(@NonNull Context context, double north)
+  public void update(double north)
   {
-    Activity top = MwmApplication.backgroundTracker(context).getTopActivity();
+    Activity top = MwmApplication.backgroundTracker().getTopActivity();
     if (top == null)
       return;
 

--- a/android/src/com/mapswithme/maps/location/GPSCheck.java
+++ b/android/src/com/mapswithme/maps/location/GPSCheck.java
@@ -19,10 +19,10 @@ public class GPSCheck extends BroadcastReceiver
   public void onReceive(Context context, Intent intent)
   {
     String msg = "onReceive: " + intent + " app in background = "
-                 + !backgroundTracker(context).isForeground();
+                 + !backgroundTracker().isForeground();
     LOGGER.i(TAG, msg);
-    if (MwmApplication.from(context).arePlatformAndCoreInitialized() &&
-        MwmApplication.backgroundTracker(context).isForeground())
+    if (MwmApplication.get().arePlatformAndCoreInitialized() &&
+        MwmApplication.backgroundTracker().isForeground())
     {
       LocationHelper.INSTANCE.restart();
     }

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -81,7 +81,7 @@ public enum LocationHelper implements Initializable<Context>
       if (mCompassData == null)
         mCompassData = new CompassData();
 
-      mCompassData.update(mContext, north);
+      mCompassData.update(north);
 
       if (mUiCallback != null)
         mUiCallback.onCompassUpdated(mCompassData);
@@ -156,12 +156,12 @@ public enum LocationHelper implements Initializable<Context>
   public void initialize(@Nullable Context context)
   {
     mContext = context;
-    mSensorHelper = new SensorHelper(context);
+    mSensorHelper = new SensorHelper();
     initProvider();
     LocationState.nativeSetListener(mMyPositionModeListener);
     LocationState.nativeSetLocationPendingTimeoutListener(mLocationPendingTimeoutListener);
-    TransitionListener transitionListener = new TransitionListener(mContext);
-    MwmApplication.backgroundTracker(context).addListener(transitionListener);
+    TransitionListener transitionListener = new TransitionListener();
+    MwmApplication.backgroundTracker().addListener(transitionListener);
   }
 
   @Override
@@ -649,7 +649,7 @@ public enum LocationHelper implements Initializable<Context>
     if (mSavedLocation != null)
       return mSavedLocation;
 
-    return AndroidNativeProvider.findBestLocation(mContext);
+    return AndroidNativeProvider.findBestLocation();
   }
 
   @Nullable

--- a/android/src/com/mapswithme/maps/location/SensorHelper.java
+++ b/android/src/com/mapswithme/maps/location/SensorHelper.java
@@ -48,9 +48,9 @@ class SensorHelper implements SensorEventListener
   @Override
   public void onAccuracyChanged(Sensor sensor, int accuracy) {}
 
-  SensorHelper(@NonNull Context context)
+  SensorHelper()
   {
-    mMwmApplication = MwmApplication.from(context);
+    mMwmApplication = MwmApplication.get();
     mSensorManager = (SensorManager) mMwmApplication.getSystemService(Context.SENSOR_SERVICE);
     if (mSensorManager != null)
       mRotation = mSensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR);

--- a/android/src/com/mapswithme/maps/location/TrackRecorder.java
+++ b/android/src/com/mapswithme/maps/location/TrackRecorder.java
@@ -66,10 +66,10 @@ public enum TrackRecorder implements Initializable<Context>
   {
     LOGGER.d(TAG, "Initialization of track recorder and setting the listener for track changes");
     mContext = context;
-    mAlarmManager = (AlarmManager) MwmApplication.from(context)
+    mAlarmManager = (AlarmManager) MwmApplication.get()
                                                  .getSystemService(Context.ALARM_SERVICE);
 
-    MwmApplication.backgroundTracker(context).addListener(foreground -> {
+    MwmApplication.backgroundTracker().addListener(foreground -> {
       LOGGER.d(TAG, "Transit to foreground: " + foreground);
 
       UiThread.cancelDelayedTasks(mStartupAwaitProc);
@@ -101,8 +101,8 @@ public enum TrackRecorder implements Initializable<Context>
 
   private PendingIntent getAlarmIntent()
   {
-    Intent intent = new Intent(MwmApplication.from(mContext), TrackRecorderWakeReceiver.class);
-    return PendingIntent.getBroadcast(MwmApplication.from(mContext), 0, intent, 0);
+    Intent intent = new Intent(MwmApplication.get(), TrackRecorderWakeReceiver.class);
+    return PendingIntent.getBroadcast(MwmApplication.get(), 0, intent, 0);
   }
 
   private void restartAlarmIfEnabled()
@@ -157,7 +157,7 @@ public enum TrackRecorder implements Initializable<Context>
 
     UiThread.cancelDelayedTasks(mStartupAwaitProc);
 
-    if (nativeIsEnabled() && !MwmApplication.backgroundTracker(mContext).isForeground())
+    if (nativeIsEnabled() && !MwmApplication.backgroundTracker().isForeground())
       TrackRecorderWakeService.start(mContext);
     else
       stop();
@@ -165,7 +165,7 @@ public enum TrackRecorder implements Initializable<Context>
 
   long getAwaitTimeout()
   {
-    return MwmApplication.prefs(mContext).getLong(LOCATION_TIMEOUT_STORED_KEY, LOCATION_TIMEOUT_MIN_MS);
+    return MwmApplication.prefs().getLong(LOCATION_TIMEOUT_STORED_KEY, LOCATION_TIMEOUT_MIN_MS);
   }
 
   private void setAwaitTimeout(long timeout)
@@ -173,7 +173,7 @@ public enum TrackRecorder implements Initializable<Context>
     LOGGER.d(TAG, "setAwaitTimeout(): " + timeout);
 
     if (timeout != getAwaitTimeout())
-      MwmApplication.prefs(mContext).edit().putLong(LOCATION_TIMEOUT_STORED_KEY, timeout).apply();
+      MwmApplication.prefs().edit().putLong(LOCATION_TIMEOUT_STORED_KEY, timeout).apply();
   }
 
   void incrementAwaitTimeout()
@@ -205,7 +205,7 @@ public enum TrackRecorder implements Initializable<Context>
       LOGGER.d(TAG, "onServiceStopped(): actually runs here");
       LocationHelper.INSTANCE.removeListener(mLocationListener);
 
-      if (!MwmApplication.backgroundTracker(mContext).isForeground())
+      if (!MwmApplication.backgroundTracker().isForeground())
         restartAlarmIfEnabled();
     });
   }

--- a/android/src/com/mapswithme/maps/location/TrackRecorderWakeReceiver.java
+++ b/android/src/com/mapswithme/maps/location/TrackRecorderWakeReceiver.java
@@ -20,7 +20,7 @@ public class TrackRecorderWakeReceiver extends BroadcastReceiver
   public void onReceive(Context context, Intent intent)
   {
     String msg = "onReceive: " + intent + " app in background = "
-                 + !backgroundTracker(context).isForeground();
+                 + !backgroundTracker().isForeground();
     LOGGER.i(TAG, msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, TAG, msg);
     TrackRecorder.INSTANCE.onWakeAlarm();

--- a/android/src/com/mapswithme/maps/location/TrackRecorderWakeService.java
+++ b/android/src/com/mapswithme/maps/location/TrackRecorderWakeService.java
@@ -33,7 +33,7 @@ public class TrackRecorderWakeService extends JobIntentService
   protected void onHandleWork(@NonNull Intent intent)
   {
     String msg = "onHandleIntent: " + intent + " app in background = "
-                 + !MwmApplication.backgroundTracker(getApplicationContext()).isForeground();
+                 + !MwmApplication.backgroundTracker().isForeground();
     LOGGER.i(TAG, msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, TAG, msg);
 

--- a/android/src/com/mapswithme/maps/location/TransitionListener.java
+++ b/android/src/com/mapswithme/maps/location/TransitionListener.java
@@ -1,6 +1,5 @@
 package com.mapswithme.maps.location;
 
-import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.location.LocationManager;
@@ -14,14 +13,6 @@ class TransitionListener implements AppBackgroundTracker.OnTransitionListener
   @NonNull
   private final GPSCheck mReceiver = new GPSCheck();
   private boolean mReceiverRegistered;
-  @SuppressWarnings("NotNullFieldNotInitialized")
-  @NonNull
-  private final Context mContext;
-
-  public TransitionListener(@NonNull Context context)
-  {
-    mContext = context;
-  }
 
   @Override
   public void onTransit(boolean foreground)
@@ -32,14 +23,14 @@ class TransitionListener implements AppBackgroundTracker.OnTransitionListener
       filter.addAction(LocationManager.PROVIDERS_CHANGED_ACTION);
       filter.addCategory(Intent.CATEGORY_DEFAULT);
 
-      MwmApplication.from(mContext).registerReceiver(mReceiver, filter);
+      MwmApplication.get().registerReceiver(mReceiver, filter);
       mReceiverRegistered = true;
       return;
     }
 
     if (!foreground && mReceiverRegistered)
     {
-      MwmApplication.from(mContext).unregisterReceiver(mReceiver);
+      MwmApplication.get().unregisterReceiver(mReceiver);
       mReceiverRegistered = false;
     }
   }

--- a/android/src/com/mapswithme/maps/maplayer/DefaultClickListener.java
+++ b/android/src/com/mapswithme/maps/maplayer/DefaultClickListener.java
@@ -20,7 +20,7 @@ public abstract class DefaultClickListener implements OnItemClickListener<Bottom
   public void onItemClick(@NonNull View v, @NonNull BottomSheetItem item)
   {
     Mode mode = item.getMode();
-    SharedPropertiesUtils.setLayerMarkerShownForLayerMode(v.getContext(), mode);
+    SharedPropertiesUtils.setLayerMarkerShownForLayerMode(mode);
     mode.toggle(v.getContext());
     onItemClickInternal(v, item);
     mAdapter.notifyDataSetChanged();

--- a/android/src/com/mapswithme/maps/maplayer/LayersAdapter.java
+++ b/android/src/com/mapswithme/maps/maplayer/LayersAdapter.java
@@ -53,8 +53,7 @@ public class LayersAdapter extends RecyclerView.Adapter<LayerHolder>
     holder.mButton.setSelected(isEnabled);
     holder.mTitle.setSelected(isEnabled);
     holder.mTitle.setText(item.getTitle());
-    boolean isNewLayer = SharedPropertiesUtils.shouldShowNewMarkerForLayerMode(context,
-                                                                               item.getMode());
+    boolean isNewLayer = SharedPropertiesUtils.shouldShowNewMarkerForLayerMode(item.getMode());
     UiUtils.showIf(isNewLayer, holder.mNewMarker);
     holder.mButton.setImageResource(isEnabled ? item.getEnabledStateDrawable()
                                               : item.getDisabledStateDrawable());

--- a/android/src/com/mapswithme/maps/maplayer/Mode.java
+++ b/android/src/com/mapswithme/maps/maplayer/Mode.java
@@ -112,8 +112,8 @@ public enum Mode
 
   public abstract void toggle(@NonNull Context context);
 
-  public boolean isNew(@NonNull Context context)
+  public boolean isNew()
   {
-    return SharedPropertiesUtils.shouldShowNewMarkerForLayerMode(context, this);
+    return SharedPropertiesUtils.shouldShowNewMarkerForLayerMode(this);
   }
 }

--- a/android/src/com/mapswithme/maps/maplayer/guides/GuidesState.java
+++ b/android/src/com/mapswithme/maps/maplayer/guides/GuidesState.java
@@ -17,7 +17,7 @@ public enum GuidesState
         @Override
         public void activate(@NonNull Context context)
         {
-          if (!SharedPropertiesUtils.shouldShowHowToUseGuidesLayerToast(context))
+          if (!SharedPropertiesUtils.shouldShowHowToUseGuidesLayerToast())
             return;
 
           UiUtils.showToastAtTop(context, R.string.routes_layer_is_on_toast);

--- a/android/src/com/mapswithme/maps/onboarding/BaseNewsFragment.java
+++ b/android/src/com/mapswithme/maps/onboarding/BaseNewsFragment.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -70,7 +69,7 @@ public abstract class BaseNewsFragment extends BaseMwmDialogFragment
 
     Adapter()
     {
-      Resources res = MwmApplication.from(requireContext()).getResources();
+      Resources res = MwmApplication.get().getResources();
 
       mTitles = getTitles(res);
       mSubtitles = res.getStringArray(getSubtitles1());
@@ -252,7 +251,7 @@ public abstract class BaseNewsFragment extends BaseMwmDialogFragment
   {
     Context context = requireContext();
 
-    if (!UiUtils.isTablet(context))
+    if (!UiUtils.isTablet())
       return;
 
     UiUtils.waitLayout(mPager, () -> {
@@ -272,8 +271,7 @@ public abstract class BaseNewsFragment extends BaseMwmDialogFragment
   @Override
   protected int getCustomTheme()
   {
-    return (UiUtils.isTablet(requireContext()) ? super.getCustomTheme()
-                                               : getFullscreenTheme());
+    return (UiUtils.isTablet() ? super.getCustomTheme() : getFullscreenTheme());
   }
 
   @StyleRes

--- a/android/src/com/mapswithme/maps/onboarding/NewsFragment.java
+++ b/android/src/com/mapswithme/maps/onboarding/NewsFragment.java
@@ -7,7 +7,6 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -124,7 +123,7 @@ public class NewsFragment extends BaseNewsFragment implements AlertDialogCallbac
   {
     Context context = activity.getApplicationContext();
 
-    if (Counters.getFirstInstallVersion(context) >= BuildConfig.VERSION_CODE)
+    if (Counters.getFirstInstallVersion() >= BuildConfig.VERSION_CODE)
       return false;
 
     FragmentManager fm = activity.getSupportFragmentManager();
@@ -144,15 +143,15 @@ public class NewsFragment extends BaseNewsFragment implements AlertDialogCallbac
     }
 
     String currentTitle = getCurrentTitleConcatenation(context);
-    String oldTitle = SharedPropertiesUtils.getWhatsNewTitleConcatenation(context);
+    String oldTitle = SharedPropertiesUtils.getWhatsNewTitleConcatenation();
     if (currentTitle.equals(oldTitle) && !recreate(activity, NewsFragment.class))
       return false;
 
     create(activity, NewsFragment.class, listener);
 
-    Counters.setWhatsNewShown(context);
-    SharedPropertiesUtils.setWhatsNewTitleConcatenation(context, currentTitle);
-    Counters.setShowReviewForOldUser(context, true);
+    Counters.setWhatsNewShown();
+    SharedPropertiesUtils.setWhatsNewTitleConcatenation(currentTitle);
+    Counters.setShowReviewForOldUser(true);
 
     return true;
   }

--- a/android/src/com/mapswithme/maps/onboarding/WelcomeDialogFragment.java
+++ b/android/src/com/mapswithme/maps/onboarding/WelcomeDialogFragment.java
@@ -2,7 +2,6 @@ package com.mapswithme.maps.onboarding;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -110,14 +109,14 @@ public class WelcomeDialogFragment extends BaseMwmDialogFragment implements View
 
   public static boolean isFirstLaunch(@NonNull FragmentActivity activity)
   {
-    if (Counters.getFirstInstallVersion(activity.getApplicationContext()) < BuildConfig.VERSION_CODE)
+    if (Counters.getFirstInstallVersion() < BuildConfig.VERSION_CODE)
       return false;
 
     FragmentManager fm = activity.getSupportFragmentManager();
     if (fm.isDestroyed())
       return false;
 
-    return !Counters.isFirstStartDialogSeen(activity);
+    return !Counters.isFirstStartDialogSeen();
   }
 
   private static void create(@NonNull FragmentActivity activity, @Nullable Bundle args)
@@ -235,11 +234,11 @@ public class WelcomeDialogFragment extends BaseMwmDialogFragment implements View
   {
     mTermOfUseCheckbox = mContentView.findViewById(R.id.term_of_use_welcome_checkbox);
     mTermOfUseCheckbox.setChecked(
-        SharedPropertiesUtils.isTermOfUseAgreementConfirmed(requireContext()));
+        SharedPropertiesUtils.isTermOfUseAgreementConfirmed());
 
     mPrivacyPolicyCheckbox = mContentView.findViewById(R.id.privacy_policy_welcome_checkbox);
     mPrivacyPolicyCheckbox.setChecked(
-        SharedPropertiesUtils.isPrivacyPolicyAgreementConfirmed(requireContext()));
+        SharedPropertiesUtils.isPrivacyPolicyAgreementConfirmed());
 
     mTermOfUseCheckbox.setOnCheckedChangeListener(
         (buttonView, isChecked) -> onTermsOfUseViewChanged(isChecked));
@@ -255,13 +254,13 @@ public class WelcomeDialogFragment extends BaseMwmDialogFragment implements View
 
   private void onPrivacyPolicyViewChanged(boolean isChecked)
   {
-    SharedPropertiesUtils.putPrivacyPolicyAgreement(requireContext(), isChecked);
+    SharedPropertiesUtils.putPrivacyPolicyAgreement(isChecked);
     onCheckedValueChanged(isChecked, mTermOfUseCheckbox.isChecked());
   }
 
   private void onTermsOfUseViewChanged(boolean isChecked)
   {
-    SharedPropertiesUtils.putTermOfUseAgreement(requireContext(), isChecked);
+    SharedPropertiesUtils.putTermOfUseAgreement(isChecked);
     onCheckedValueChanged(isChecked, mPrivacyPolicyCheckbox.isChecked());
   }
 
@@ -308,7 +307,7 @@ public class WelcomeDialogFragment extends BaseMwmDialogFragment implements View
 
   private void onDeclineBtnClicked()
   {
-    Counters.setFirstStartDialogSeen(requireContext());
+    Counters.setFirstStartDialogSeen();
     trackStatisticEvent(Statistics.EventName.ONBOARDING_SCREEN_DECLINE);
     dismissAllowingStateLoss();
   }
@@ -341,7 +340,7 @@ public class WelcomeDialogFragment extends BaseMwmDialogFragment implements View
     if (mOnboardinStep != null && mOnboardingStepPassedListener != null)
       mOnboardingStepPassedListener.onOnboardingStepPassed(mOnboardinStep);
 
-    Counters.setFirstStartDialogSeen(requireContext());
+    Counters.setFirstStartDialogSeen();
     dismissAllowingStateLoss();
 
     if (mOnboardingStepPassedListener != null)
@@ -352,16 +351,16 @@ public class WelcomeDialogFragment extends BaseMwmDialogFragment implements View
   public void onCancel(DialogInterface dialog)
   {
     super.onCancel(dialog);
-    if (!isAgreementDeclined(requireContext()))
-      Counters.setFirstStartDialogSeen(requireContext());
+    if (!isAgreementDeclined())
+      Counters.setFirstStartDialogSeen();
     if (mOnboardingStepPassedListener != null)
       mOnboardingStepPassedListener.onOnboardingStepCancelled();
   }
 
-  public static boolean isAgreementDeclined(@NonNull Context context)
+  public static boolean isAgreementDeclined()
   {
-    return !SharedPropertiesUtils.isTermOfUseAgreementConfirmed(context)
-           || !SharedPropertiesUtils.isPrivacyPolicyAgreementConfirmed(context);
+    return !SharedPropertiesUtils.isTermOfUseAgreementConfirmed()
+           || !SharedPropertiesUtils.isPrivacyPolicyAgreementConfirmed();
 
   }
 

--- a/android/src/com/mapswithme/maps/routing/BaseRoutingErrorDialogFragment.java
+++ b/android/src/com/mapswithme/maps/routing/BaseRoutingErrorDialogFragment.java
@@ -24,7 +24,6 @@ import com.mapswithme.maps.R;
 import com.mapswithme.maps.adapter.DisabledChildSimpleExpandableListAdapter;
 import com.mapswithme.maps.base.BaseMwmDialogFragment;
 import com.mapswithme.maps.downloader.CountryItem;
-import com.mapswithme.maps.downloader.MapManager;
 import com.mapswithme.util.StringUtils;
 import com.mapswithme.util.UiUtils;
 
@@ -106,7 +105,7 @@ abstract class BaseRoutingErrorDialogFragment extends BaseMwmDialogFragment
     ((TextView) countryView.findViewById(R.id.tv__title)).setText(map.name);
 
     final TextView szView = (TextView) countryView.findViewById(R.id.tv__size);
-    szView.setText(StringUtils.getFileSizeString(requireContext(), map.totalSize));
+    szView.setText(StringUtils.getFileSizeString(map.totalSize));
     ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) szView.getLayoutParams();
     lp.rightMargin = 0;
     szView.setLayoutParams(lp);
@@ -167,7 +166,7 @@ abstract class BaseRoutingErrorDialogFragment extends BaseMwmDialogFragment
 
     Map<String, String> group = new HashMap<>();
     group.put(GROUP_NAME, getString(R.string.maps) + " (" + mMissingMaps.size() + ") ");
-    group.put(GROUP_SIZE, StringUtils.getFileSizeString(requireContext(), size));
+    group.put(GROUP_SIZE, StringUtils.getFileSizeString(size));
 
     List<Map<String, String>> groups = new ArrayList<>();
     groups.add(group);

--- a/android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
+++ b/android/src/com/mapswithme/maps/routing/ResultCodesHelper.java
@@ -1,6 +1,5 @@
 package com.mapswithme.maps.routing;
 
-import android.content.Context;
 import android.content.res.Resources;
 import android.util.Pair;
 
@@ -35,10 +34,9 @@ class ResultCodesHelper
   static final int HAS_WARNINGS = 16;
 
   @NonNull
-  static ResourcesHolder getDialogTitleSubtitle(@NonNull Context context,
-                                                int errorCode, int missingCount)
+  static ResourcesHolder getDialogTitleSubtitle(int errorCode, int missingCount)
   {
-    Resources resources = MwmApplication.from(context).getResources();
+    Resources resources = MwmApplication.get().getResources();
     int titleRes = 0;
     List<String> messages = new ArrayList<>();
     @StringRes

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -14,7 +14,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Pair;
-import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import com.mapswithme.maps.Framework;
 import com.mapswithme.maps.MwmApplication;
@@ -386,7 +385,7 @@ public class RoutingController implements TaxiManager.TaxiListener, Initializabl
     for (int resId : new int[] { R.string.dialog_routing_disclaimer_priority, R.string.dialog_routing_disclaimer_precision,
                                  R.string.dialog_routing_disclaimer_recommendations, R.string.dialog_routing_disclaimer_borders,
                                  R.string.dialog_routing_disclaimer_beware })
-      builder.append(MwmApplication.from(activity.getApplicationContext()).getString(resId)).append("\n\n");
+      builder.append(MwmApplication.get().getString(resId)).append("\n\n");
 
     new AlertDialog.Builder(activity)
         .setTitle(R.string.dialog_routing_disclaimer_title)

--- a/android/src/com/mapswithme/maps/routing/RoutingErrorDialogFragment.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingErrorDialogFragment.java
@@ -33,7 +33,7 @@ public class RoutingErrorDialogFragment extends BaseRoutingErrorDialogFragment
     super.beforeDialogCreated(builder);
 
     ResultCodesHelper.ResourcesHolder resHolder =
-        ResultCodesHelper.getDialogTitleSubtitle(requireContext(), mResultCode, mMissingMaps.size());
+        ResultCodesHelper.getDialogTitleSubtitle(mResultCode, mMissingMaps.size());
     Pair<String, String> titleMessage = resHolder.getTitleMessage();
 
     builder.setTitle(titleMessage.first);

--- a/android/src/com/mapswithme/maps/routing/RoutingPlanController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingPlanController.java
@@ -111,8 +111,7 @@ public class RoutingPlanController extends ToolbarController
 
     btn.setOnClickListener(v -> DrivingOptionsActivity.start(requireActivity()));
     mDriverOptionsLayoutListener = new SelfTerminatedDrivingOptionsLayoutListener();
-    mAnimToggle = MwmApplication.from(activity.getApplicationContext())
-                                .getResources().getInteger(R.integer.anim_default);
+    mAnimToggle = MwmApplication.get().getResources().getInteger(R.integer.anim_default);
   }
 
   @NonNull

--- a/android/src/com/mapswithme/maps/search/SearchFragment.java
+++ b/android/src/com/mapswithme/maps/search/SearchFragment.java
@@ -502,7 +502,7 @@ public class SearchFragment extends BaseMwmFragment
     if (mHiddenCommands.isEmpty())
     {
       mHiddenCommands.addAll(
-          Arrays.asList(new BadStorageCommand("?emulateBadStorage", requireContext()),
+          Arrays.asList(new BadStorageCommand("?emulateBadStorage"),
                         new JavaCrashCommand("?emulateJavaCrash"),
                         new NativeCrashCommand("?emulateNativeCrash"),
                         new PushTokenCommand("?pushToken")));
@@ -773,19 +773,16 @@ public class SearchFragment extends BaseMwmFragment
 
   private static class BadStorageCommand extends HiddenCommand.BaseHiddenCommand
   {
-    @NonNull
-    Context mContext;
 
-    BadStorageCommand(@NonNull String command, @NonNull Context context)
+    BadStorageCommand(@NonNull String command)
     {
       super(command);
-      mContext = context;
     }
 
     @Override
     void executeInternal()
     {
-      SharedPropertiesUtils.setShouldShowEmulateBadStorageSetting(mContext, true);
+      SharedPropertiesUtils.setShouldShowEmulateBadStorageSetting(true);
     }
   }
 

--- a/android/src/com/mapswithme/maps/settings/BaseXmlSettingsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/BaseXmlSettingsFragment.java
@@ -9,7 +9,6 @@ import androidx.preference.PreferenceFragmentCompat;
 import android.view.View;
 
 import com.mapswithme.maps.R;
-import com.mapswithme.util.Config;
 import com.mapswithme.util.ThemeUtils;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.Utils;
@@ -28,7 +27,7 @@ abstract class BaseXmlSettingsFragment extends PreferenceFragmentCompat
   public void onAttach(Context context)
   {
     super.onAttach(context);
-    Utils.detachFragmentIfCoreNotInitialized(context, this);
+    Utils.detachFragmentIfCoreNotInitialized(this);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
@@ -37,7 +37,6 @@ import com.mapswithme.maps.location.LocationHelper;
 import com.mapswithme.maps.location.TrackRecorder;
 import com.mapswithme.maps.purchase.AdsRemovalActivationCallback;
 import com.mapswithme.maps.purchase.AdsRemovalPurchaseControllerProvider;
-import com.mapswithme.maps.purchase.AdsRemovalPurchaseDialog;
 import com.mapswithme.maps.purchase.PurchaseCallback;
 import com.mapswithme.maps.purchase.PurchaseController;
 import com.mapswithme.maps.purchase.PurchaseFactory;
@@ -595,7 +594,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     if (pref == null)
       return;
 
-    if (!SharedPropertiesUtils.shouldShowEmulateBadStorageSetting(requireContext()))
+    if (!SharedPropertiesUtils.shouldShowEmulateBadStorageSetting())
       removePreference(getString(R.string.pref_settings_general), pref);
   }
 
@@ -656,13 +655,13 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     if (pref == null)
       return;
 
-    ((TwoStatePreference)pref).setChecked(SharedPropertiesUtils.isStatisticsEnabled(requireContext()));
+    ((TwoStatePreference)pref).setChecked(SharedPropertiesUtils.isStatisticsEnabled());
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
     {
       @Override
       public boolean onPreferenceChange(Preference preference, Object newValue)
       {
-        Statistics.INSTANCE.setStatEnabled(requireContext(), (Boolean) newValue);
+        Statistics.INSTANCE.setStatEnabled((Boolean) newValue);
         return true;
       }
     });
@@ -689,7 +688,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
       {
         boolean enabled = (Boolean) newValue;
         TrackRecorder.INSTANCE.setEnabled(enabled);
-        Statistics.INSTANCE.setStatEnabled(requireContext(), enabled);
+        Statistics.INSTANCE.setStatEnabled(enabled);
         trackPref.setEnabled(enabled);
         if (root != null)
           root.setSummary(enabled ? R.string.on : R.string.off);

--- a/android/src/com/mapswithme/maps/sound/TtsPlayer.java
+++ b/android/src/com/mapswithme/maps/sound/TtsPlayer.java
@@ -48,10 +48,6 @@ public enum TtsPlayer implements Initializable<Context>
   private TextToSpeech mTts;
   private boolean mInitializing;
 
-  @SuppressWarnings("NotNullFieldNotInitialized")
-  @NonNull
-  private Context mContext;
-
   // TTS is locked down due to absence of supported languages
   private boolean mUnavailable;
 
@@ -144,8 +140,6 @@ public enum TtsPlayer implements Initializable<Context>
   @Override
   public void initialize(@Nullable Context context)
   {
-    mContext = context;
-
     if (mTts != null || mInitializing || mUnavailable)
       return;
 
@@ -235,7 +229,7 @@ public enum TtsPlayer implements Initializable<Context>
 
   private boolean getUsableLanguages(List<LanguageData> outList)
   {
-    Resources resources = MwmApplication.from(mContext).getResources();
+    Resources resources = MwmApplication.get().getResources();
     String[] codes = resources.getStringArray(R.array.tts_languages_supported);
     String[] names = resources.getStringArray(R.array.tts_language_names);
 

--- a/android/src/com/mapswithme/maps/tips/Tutorial.java
+++ b/android/src/com/mapswithme/maps/tips/Tutorial.java
@@ -1,7 +1,6 @@
 package com.mapswithme.maps.tips;
 
 import android.app.Activity;
-import android.content.Context;
 import android.graphics.Typeface;
 import android.view.View;
 
@@ -171,10 +170,9 @@ public enum Tutorial
   public abstract ClickInterceptor createClickInterceptor();
 
   @NonNull
-  public static <T> Tutorial requestCurrent(@NonNull Context context,
-                                            @NonNull Class<T> requiredScreenClass)
+  public static <T> Tutorial requestCurrent(@NonNull Class<T> requiredScreenClass)
   {
-    if (MwmApplication.from(context).isFirstLaunch())
+    if (MwmApplication.get().isFirstLaunch())
       return STUB;
 
     int index = Framework.nativeGetCurrentTipIndex();

--- a/android/src/com/mapswithme/maps/tips/TutorialClickListener.java
+++ b/android/src/com/mapswithme/maps/tips/TutorialClickListener.java
@@ -27,7 +27,7 @@ public abstract class TutorialClickListener implements View.OnClickListener
   @Override
   public final void onClick(View v)
   {
-    Tutorial tutorial = Tutorial.requestCurrent(mActivity, mActivity.getClass());
+    Tutorial tutorial = Tutorial.requestCurrent(mActivity.getClass());
     if (tutorial == mTutorial && tutorial != Tutorial.STUB)
     {
       MwmActivity mwmActivity = (MwmActivity) mActivity;

--- a/android/src/com/mapswithme/maps/ugc/UGC.java
+++ b/android/src/com/mapswithme/maps/ugc/UGC.java
@@ -48,7 +48,7 @@ public class UGC
   public static void init(final @NonNull Context context)
   {
     final AppBackgroundTracker.OnTransitionListener listener = new UploadUgcTransitionListener(context);
-    MwmApplication.backgroundTracker(context).addListener(listener);
+    MwmApplication.backgroundTracker().addListener(listener);
   }
 
   private UGC(@NonNull Rating[] ratings, float averageRating, @Nullable Review[] reviews,

--- a/android/src/com/mapswithme/maps/widget/menu/MainMenu.java
+++ b/android/src/com/mapswithme/maps/widget/menu/MainMenu.java
@@ -250,7 +250,7 @@ public class MainMenu extends BaseMenu
 
     for (Mode mode : Mode.values())
     {
-      show = SharedPropertiesUtils.shouldShowNewMarkerForLayerMode(mFrame.getContext(), mode);
+      show = SharedPropertiesUtils.shouldShowNewMarkerForLayerMode(mode);
       if (show)
         break;
     }

--- a/android/src/com/mapswithme/maps/widget/menu/NavMenu.java
+++ b/android/src/com/mapswithme/maps/widget/menu/NavMenu.java
@@ -79,8 +79,7 @@ public class NavMenu extends BaseMenu
   public NavMenu(View frame, ItemClickListener<Item> listener)
   {
     super(frame, listener);
-    mAnimationDuration = MwmApplication.from(frame.getContext())
-                                       .getResources().getInteger(R.integer.anim_menu);
+    mAnimationDuration = MwmApplication.get().getResources().getInteger(R.integer.anim_menu);
     mContentFrame = mFrame.findViewById(R.id.content_frame);
     mToggleImage = new RotateDrawable(Graphics.tint(mFrame.getContext(), R.drawable.ic_menu_close, R.attr.iconTintLight));
     ImageView toggle = (ImageView) mLineFrame.findViewById(R.id.toggle);

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageButtons.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageButtons.java
@@ -91,7 +91,7 @@ public final class PlacePageButtons
       }
 
       @DrawableRes
-      public int getEnabledStateResId(@NonNull Context context)
+      public int getEnabledStateResId()
       {
         return mEnabledStateResId;
       }
@@ -110,7 +110,7 @@ public final class PlacePageButtons
         }
 
         @Override
-        public int getEnabledStateResId(@NonNull Context context)
+        public int getEnabledStateResId()
         {
           throw new UnsupportedOperationException("Not supported here");
         }
@@ -294,9 +294,9 @@ public final class PlacePageButtons
         new ImageResources.Stub()
         {
           @Override
-          public int getEnabledStateResId(@NonNull Context context)
+          public int getEnabledStateResId()
           {
-            return ThemeUtils.getResource(MwmApplication.from(context),
+            return ThemeUtils.getResource(MwmApplication.get(),
                                           android.R.attr.homeAsUpIndicator);
           }
         },
@@ -494,7 +494,7 @@ public final class PlacePageButtons
     for (int i = mMaxButtons; i < buttons.size(); i++)
     {
       PlacePageButton bsItem = buttons.get(i);
-      int iconRes = bsItem.getIcon().getEnabledStateResId(mPlacePage.getContext());
+      int iconRes = bsItem.getIcon().getEnabledStateResId();
       bs.sheet(i, iconRes, bsItem.getTitle());
     }
 
@@ -522,7 +522,7 @@ public final class PlacePageButtons
     TextView title = (TextView) parent.findViewById(R.id.title);
 
     title.setText(current.getTitle());
-    icon.setImageResource(current.getIcon().getEnabledStateResId(context));
+    icon.setImageResource(current.getIcon().getEnabledStateResId());
     mItemListener.onPrepareVisibleView(current, parent, icon, title);
     parent.setOnClickListener(new ShowPopupClickListener(current, items));
     return parent;

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -401,7 +401,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
   public PlacePageView(Context context, AttributeSet attrs, int defStyleAttr)
   {
     super(context, attrs);
-    mIsLatLonDms = MwmApplication.prefs(context).getBoolean(PREF_USE_DMS, false);
+    mIsLatLonDms = MwmApplication.prefs().getBoolean(PREF_USE_DMS, false);
     mGalleryAdapter = new com.mapswithme.maps.widget.placepage.GalleryAdapter(context);
     init(attrs, defStyleAttr);
   }
@@ -1566,7 +1566,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
       }
     }
 
-    UiUtils.setTextAndShow(mFullOpeningHours, TimeFormatUtils.formatTimetables(getContext(), timetables));
+    UiUtils.setTextAndShow(mFullOpeningHours, TimeFormatUtils.formatTimetables(timetables));
     if (!containsCurrentWeekday)
       refreshTodayOpeningHours(resources.getString(R.string.day_off_today), resources.getColor(R.color.base_red));
   }
@@ -1862,7 +1862,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
         break;
       case R.id.ll__place_latlon:
         mIsLatLonDms = !mIsLatLonDms;
-        MwmApplication.prefs(getContext()).edit().putBoolean(PREF_USE_DMS, mIsLatLonDms).apply();
+        MwmApplication.prefs().edit().putBoolean(PREF_USE_DMS, mIsLatLonDms).apply();
         if (mMapObject == null)
         {
           LOGGER.e(TAG, "A LatLon cannot be refreshed, mMapObject is null");
@@ -2081,7 +2081,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
 
     mDownloaderIcon.update(country);
 
-    StringBuilder sb = new StringBuilder(StringUtils.getFileSizeString(getContext(), country.totalSize));
+    StringBuilder sb = new StringBuilder(StringUtils.getFileSizeString(country.totalSize));
     if (country.isExpandable())
       sb.append(String.format(Locale.US, "  •  %s: %d", getContext().getString(R.string.downloader_status_maps), country.totalChildCount));
 

--- a/android/src/com/mapswithme/util/BatteryState.java
+++ b/android/src/com/mapswithme/util/BatteryState.java
@@ -26,12 +26,12 @@ public final class BatteryState
   private BatteryState() {}
 
   @NonNull
-  public static State getState(@NonNull Context context)
+  public static State getState()
   {
     IntentFilter filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
     // Because it's a sticky intent, you don't need to register a BroadcastReceiver
     // by simply calling registerReceiver passing in null
-    Intent batteryStatus = MwmApplication.from(context).registerReceiver(null, filter);
+    Intent batteryStatus = MwmApplication.get().registerReceiver(null, filter);
     if (batteryStatus == null)
       return new State(0, CHARGING_STATUS_UNKNOWN);
 
@@ -43,7 +43,7 @@ public final class BatteryState
   @IntRange(from=0, to=100)
   public static int getLevel(@NonNull Context context)
   {
-    return getState(context).getLevel();
+    return getState().getLevel();
   }
 
   @IntRange(from=0, to=100)
@@ -57,7 +57,7 @@ public final class BatteryState
   @ChargingStatus
   public static int getChargingStatus(@NonNull Context context)
   {
-    return getState(context).getChargingStatus();
+    return getState().getChargingStatus();
   }
 
   @ChargingStatus

--- a/android/src/com/mapswithme/util/Config.java
+++ b/android/src/com/mapswithme/util/Config.java
@@ -105,10 +105,10 @@ public final class Config
     nativeSetBoolean(key, value);
   }
 
-  public static void migrateCountersToSharedPrefs(@NonNull Context context)
+  public static void migrateCountersToSharedPrefs()
   {
     int version = getInt(KEY_APP_FIRST_INSTALL_VERSION, BuildConfig.VERSION_CODE);
-    MwmApplication.prefs(context)
+    MwmApplication.prefs()
                   .edit()
                   .putInt(KEY_APP_LAUNCH_NUMBER, getInt(KEY_APP_LAUNCH_NUMBER))
                   .putInt(KEY_APP_FIRST_INSTALL_VERSION, version)
@@ -210,7 +210,7 @@ public final class Config
   @NonNull
   public static String getCurrentUiTheme(@NonNull Context context)
   {
-    String defaultTheme = MwmApplication.from(context).getString(R.string.theme_default);
+    String defaultTheme = MwmApplication.get().getString(R.string.theme_default);
     String res = getString(KEY_MISC_UI_THEME, defaultTheme);
 
     if (ThemeUtils.isValidTheme(context, res))
@@ -230,7 +230,7 @@ public final class Config
   @NonNull
   public static String getUiThemeSettings(@NonNull Context context)
   {
-    String autoTheme = MwmApplication.from(context).getString(R.string.theme_auto);
+    String autoTheme = MwmApplication.get().getString(R.string.theme_auto);
     String res = getString(KEY_MISC_UI_THEME_SETTINGS, autoTheme);
     if (ThemeUtils.isValidTheme(context, res) || ThemeUtils.isAutoTheme(context, res))
       return res;

--- a/android/src/com/mapswithme/util/ConnectionState.java
+++ b/android/src/com/mapswithme/util/ConnectionState.java
@@ -8,11 +8,10 @@ import android.telephony.TelephonyManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.mapswithme.maps.MwmApplication;
-import com.mapswithme.maps.base.Initializable;
 
 import static com.mapswithme.util.ConnectionState.Type.NONE;
 
-public enum ConnectionState implements Initializable<Context>
+public enum ConnectionState
 {
   INSTANCE;
 
@@ -20,9 +19,6 @@ public enum ConnectionState implements Initializable<Context>
   private static final byte CONNECTION_NONE = 0;
   private static final byte CONNECTION_WIFI = 1;
   private static final byte CONNECTION_WWAN = 2;
-  @SuppressWarnings("NotNullFieldNotInitialized")
-  @NonNull
-  private Context mContext;
 
   public enum Type
   {
@@ -50,18 +46,6 @@ public enum ConnectionState implements Initializable<Context>
     }
   }
 
-  @Override
-  public void initialize(@Nullable Context context)
-  {
-    mContext = MwmApplication.from(context);
-  }
-
-  @Override
-  public void destroy()
-  {
-    // No op
-  }
-
   private boolean isNetworkConnected(int networkType)
   {
     final NetworkInfo info = getActiveNetwork();
@@ -72,7 +56,7 @@ public enum ConnectionState implements Initializable<Context>
   public NetworkInfo getActiveNetwork()
   {
     ConnectivityManager manager =
-        ((ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE));
+        ((ConnectivityManager) MwmApplication.get().getSystemService(Context.CONNECTIVITY_SERVICE));
     if (manager == null)
       return null;
 

--- a/android/src/com/mapswithme/util/Counters.java
+++ b/android/src/com/mapswithme/util/Counters.java
@@ -1,6 +1,5 @@
 package com.mapswithme.util;
 
-import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.PreferenceManager;
@@ -28,59 +27,59 @@ public final class Counters
 
   private Counters() {}
 
-  public static void initCounters(@NonNull Context context)
+  public static void initCounters()
   {
-    PreferenceManager.setDefaultValues(context, R.xml.prefs_main, false);
-    updateLaunchCounter(context);
+    PreferenceManager.setDefaultValues(MwmApplication.get(), R.xml.prefs_main, false);
+    updateLaunchCounter();
   }
 
-  public static int getFirstInstallVersion(@NonNull Context context)
+  public static int getFirstInstallVersion()
   {
-    return MwmApplication.prefs(context).getInt(KEY_APP_FIRST_INSTALL_VERSION, 0);
+    return MwmApplication.prefs().getInt(KEY_APP_FIRST_INSTALL_VERSION, 0);
   }
 
-  public static boolean isFirstStartDialogSeen(@NonNull Context context)
+  public static boolean isFirstStartDialogSeen()
   {
-    return MwmApplication.prefs(context).getBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, false);
+    return MwmApplication.prefs().getBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, false);
   }
 
-  public static void setFirstStartDialogSeen(@NonNull Context context)
+  public static void setFirstStartDialogSeen()
   {
-    MwmApplication.prefs(context)
+    MwmApplication.prefs()
                   .edit()
                   .putBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, true)
                   .apply();
   }
 
 
-  public static void setWhatsNewShown(@NonNull Context context)
+  public static void setWhatsNewShown()
   {
-    MwmApplication.prefs(context)
+    MwmApplication.prefs()
                   .edit()
                   .putInt(KEY_MISC_NEWS_LAST_VERSION, BuildConfig.VERSION_CODE)
                   .apply();
   }
 
-  public static void resetAppSessionCounters(@NonNull Context context)
+  public static void resetAppSessionCounters()
   {
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .putInt(KEY_APP_LAUNCH_NUMBER, 0)
                   .putInt(KEY_APP_SESSION_NUMBER, 0)
                   .putLong(KEY_APP_LAST_SESSION_TIMESTAMP, 0L)
                   .putInt(KEY_LIKES_LAST_RATED_SESSION, 0)
                   .apply();
-    incrementSessionNumber(context);
+    incrementSessionNumber();
   }
 
-  public static boolean isSessionRated(@NonNull Context context, int session)
+  public static boolean isSessionRated(int session)
   {
-    return (MwmApplication.prefs(context).getInt(KEY_LIKES_LAST_RATED_SESSION,
+    return (MwmApplication.prefs().getInt(KEY_LIKES_LAST_RATED_SESSION,
                                                  0) >= session);
   }
 
-  public static void setRatedSession(@NonNull Context context, int session)
+  public static void setRatedSession(int session)
   {
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .putInt(KEY_LIKES_LAST_RATED_SESSION, session)
                   .apply();
   }
@@ -88,108 +87,106 @@ public final class Counters
   /**
    * Session = single day, when app was started any number of times.
    */
-  public static int getSessionCount(@NonNull Context context)
+  public static int getSessionCount()
   {
-    return MwmApplication.prefs(context).getInt(KEY_APP_SESSION_NUMBER, 0);
+    return MwmApplication.prefs().getInt(KEY_APP_SESSION_NUMBER, 0);
   }
 
-  public static boolean isRatingApplied(@NonNull Context context,
-                                        Class<? extends DialogFragment> dialogFragmentClass)
+  public static boolean isRatingApplied(Class<? extends DialogFragment> dialogFragmentClass)
   {
-    return MwmApplication.prefs(context)
+    return MwmApplication.prefs()
                          .getBoolean(KEY_LIKES_RATED_DIALOG + dialogFragmentClass.getSimpleName(),
                                      false);
   }
 
-  public static void setRatingApplied(@NonNull Context context,
-                                      Class<? extends DialogFragment> dialogFragmentClass)
+  public static void setRatingApplied(Class<? extends DialogFragment> dialogFragmentClass)
   {
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .putBoolean(KEY_LIKES_RATED_DIALOG + dialogFragmentClass.getSimpleName(), true)
                   .apply();
   }
 
-  public static String getInstallFlavor(@NonNull Context context)
+  public static String getInstallFlavor()
   {
-    return MwmApplication.prefs(context).getString(KEY_APP_FIRST_INSTALL_FLAVOR, "");
+    return MwmApplication.prefs().getString(KEY_APP_FIRST_INSTALL_FLAVOR, "");
   }
 
-  private static void updateLaunchCounter(@NonNull Context context)
+  private static void updateLaunchCounter()
   {
-    if (incrementLaunchNumber(context) == 0)
+    if (incrementLaunchNumber() == 0)
     {
-      if (getFirstInstallVersion(context) == 0)
+      if (getFirstInstallVersion() == 0)
       {
-        MwmApplication.prefs(context)
+        MwmApplication.prefs()
                       .edit()
                       .putInt(KEY_APP_FIRST_INSTALL_VERSION, BuildConfig.VERSION_CODE)
                       .apply();
       }
 
-      updateInstallFlavor(context);
+      updateInstallFlavor();
     }
 
-    incrementSessionNumber(context);
+    incrementSessionNumber();
   }
 
-  private static int incrementLaunchNumber(@NonNull Context context)
+  private static int incrementLaunchNumber()
   {
-    return increment(context, KEY_APP_LAUNCH_NUMBER);
+    return increment(KEY_APP_LAUNCH_NUMBER);
   }
 
-  private static void updateInstallFlavor(@NonNull Context context)
+  private static void updateInstallFlavor()
   {
-    String installedFlavor = getInstallFlavor(context);
+    String installedFlavor = getInstallFlavor();
     if (TextUtils.isEmpty(installedFlavor))
     {
-      MwmApplication.prefs(context).edit()
+      MwmApplication.prefs().edit()
                     .putString(KEY_APP_FIRST_INSTALL_FLAVOR, BuildConfig.FLAVOR)
                     .apply();
     }
   }
 
-  private static void incrementSessionNumber(@NonNull Context context)
+  private static void incrementSessionNumber()
   {
-    long lastSessionTimestamp = MwmApplication.prefs(context)
+    long lastSessionTimestamp = MwmApplication.prefs()
                                               .getLong(KEY_APP_LAST_SESSION_TIMESTAMP, 0);
     if (DateUtils.isToday(lastSessionTimestamp))
       return;
 
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .putLong(KEY_APP_LAST_SESSION_TIMESTAMP, System.currentTimeMillis())
                   .apply();
-    increment(context, KEY_APP_SESSION_NUMBER);
+    increment(KEY_APP_SESSION_NUMBER);
   }
 
-  private static int increment(@NonNull Context context, @NonNull String key)
+  private static int increment(@NonNull String key)
   {
-    int value = MwmApplication.prefs(context).getInt(key, 0);
-    MwmApplication.prefs(context).edit()
+    int value = MwmApplication.prefs().getInt(key, 0);
+    MwmApplication.prefs().edit()
                   .putInt(key, ++value)
                   .apply();
     return value;
   }
 
-  public static void setShowReviewForOldUser(@NonNull Context context, boolean value)
+  public static void setShowReviewForOldUser(boolean value)
   {
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .putBoolean(KEY_SHOW_REVIEW_FOR_OLD_USER, value)
                   .apply();
   }
 
-  public static boolean isShowReviewForOldUser(@NonNull Context context)
+  public static boolean isShowReviewForOldUser()
   {
-    return MwmApplication.prefs(context).getBoolean(KEY_SHOW_REVIEW_FOR_OLD_USER, false);
+    return MwmApplication.prefs().getBoolean(KEY_SHOW_REVIEW_FOR_OLD_USER, false);
   }
 
-  public static boolean isMigrationNeeded(@NonNull Context context)
+  public static boolean isMigrationNeeded()
   {
-    return !MwmApplication.prefs(context).getBoolean(KEY_MIGRATION_EXECUTED, false);
+    return !MwmApplication.prefs().getBoolean(KEY_MIGRATION_EXECUTED, false);
   }
 
-  public static void setMigrationExecuted(@NonNull Context context)
+  public static void setMigrationExecuted()
   {
-    MwmApplication.prefs(context).edit()
+    MwmApplication.prefs().edit()
                   .putBoolean(KEY_MIGRATION_EXECUTED, true)
                   .apply();
   }

--- a/android/src/com/mapswithme/util/CrashlyticsUtils.java
+++ b/android/src/com/mapswithme/util/CrashlyticsUtils.java
@@ -1,21 +1,15 @@
 package com.mapswithme.util;
 
-import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.mapswithme.maps.MwmApplication;
-import com.mapswithme.maps.base.Initializable;
 
-public enum CrashlyticsUtils implements Initializable<Context>
+public enum CrashlyticsUtils
 {
   INSTANCE;
-
-  @SuppressWarnings("NotNullFieldNotInitialized")
-  @NonNull
-  private Context mContext;
 
   public void logException(@NonNull Throwable exception)
   {
@@ -35,7 +29,7 @@ public enum CrashlyticsUtils implements Initializable<Context>
 
   private boolean checkCrashlytics()
   {
-    MwmApplication app = MwmApplication.from(mContext);
+    MwmApplication app = MwmApplication.get();
     return app.getMediator().isCrashlyticsEnabled();
   }
 
@@ -57,17 +51,5 @@ public enum CrashlyticsUtils implements Initializable<Context>
       default:
         throw new IllegalArgumentException("Undetermined log level: " + level);
     }
-  }
-
-  @Override
-  public void initialize(@Nullable Context context)
-  {
-    mContext = MwmApplication.from(context);
-  }
-
-  @Override
-  public void destroy()
-  {
-    // No op
   }
 }

--- a/android/src/com/mapswithme/util/MultipleTrackerReferrerReceiver.java
+++ b/android/src/com/mapswithme/util/MultipleTrackerReferrerReceiver.java
@@ -23,10 +23,10 @@ public class MultipleTrackerReferrerReceiver extends BroadcastReceiver
   public void onReceive(Context context, Intent intent)
   {
     String msg = "onReceive: " + intent + " app in background = "
-                 + !backgroundTracker(context).isForeground();
+                 + !backgroundTracker().isForeground();
     LOGGER.i(TAG, msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, TAG, msg);
-    Counters.initCounters(context);
+    Counters.initCounters();
     // parse & send referrer to Aloha
     try
     {

--- a/android/src/com/mapswithme/util/SharedPropertiesUtils.java
+++ b/android/src/com/mapswithme/util/SharedPropertiesUtils.java
@@ -1,6 +1,5 @@
 package com.mapswithme.util;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
@@ -35,119 +34,117 @@ public final class SharedPropertiesUtils
     throw new IllegalStateException("Try instantiate utility class SharedPropertiesUtils");
   }
 
-  public static boolean isStatisticsEnabled(@NonNull Context context)
+  public static boolean isStatisticsEnabled()
   {
-    return MwmApplication.prefs(context).getBoolean(KEY_PREF_STATISTICS, true);
+    return MwmApplication.prefs().getBoolean(KEY_PREF_STATISTICS, true);
   }
 
-  public static void setStatisticsEnabled(@NonNull Context context, boolean enabled)
+  public static void setStatisticsEnabled(boolean enabled)
   {
-    MwmApplication.prefs(context).edit().putBoolean(KEY_PREF_STATISTICS, enabled).apply();
+    MwmApplication.prefs().edit().putBoolean(KEY_PREF_STATISTICS, enabled).apply();
   }
 
-  public static void setShouldShowEmulateBadStorageSetting(@NonNull Context context, boolean show)
+  public static void setShouldShowEmulateBadStorageSetting(boolean show)
   {
     SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
+        .getDefaultSharedPreferences(MwmApplication.get());
     prefs.edit().putBoolean(PREFS_SHOW_EMULATE_BAD_STORAGE_SETTING, show).apply();
   }
 
-  public static boolean shouldShowEmulateBadStorageSetting(@NonNull Context context)
+  public static boolean shouldShowEmulateBadStorageSetting()
   {
     SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
+        .getDefaultSharedPreferences(MwmApplication.get());
     return prefs.getBoolean(PREFS_SHOW_EMULATE_BAD_STORAGE_SETTING, false);
   }
 
-  public static boolean shouldEmulateBadExternalStorage(@NonNull Context context)
+  public static boolean shouldEmulateBadExternalStorage()
   {
     SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
-    String key = MwmApplication.from(context).getString(R.string.pref_emulate_bad_external_storage);
+        .getDefaultSharedPreferences(MwmApplication.get());
+    String key = MwmApplication.get().getString(R.string.pref_emulate_bad_external_storage);
     return prefs.getBoolean(key, false);
   }
 
-  public static void setBackupWidgetExpanded(@NonNull Context context, boolean expanded)
+  public static void setBackupWidgetExpanded(boolean expanded)
   {
     SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
+        .getDefaultSharedPreferences(MwmApplication.get());
     prefs.edit().putBoolean(PREFS_BACKUP_WIDGET_EXPANDED, expanded).apply();
   }
 
-  public static boolean getBackupWidgetExpanded(@NonNull Context context)
+  public static boolean getBackupWidgetExpanded()
   {
     SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
+        .getDefaultSharedPreferences(MwmApplication.get());
     return prefs.getBoolean(PREFS_BACKUP_WIDGET_EXPANDED, true);
   }
 
   @Nullable
-  public static String getWhatsNewTitleConcatenation(@NonNull Context context)
+  public static String getWhatsNewTitleConcatenation()
   {
     SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
+        .getDefaultSharedPreferences(MwmApplication.get());
     return prefs.getString(PREFS_WHATS_NEW_TITLE_CONCATENATION, null);
   }
 
-  public static void setWhatsNewTitleConcatenation(@NonNull Context context,
-                                                   @NonNull String concatenation)
+  public static void setWhatsNewTitleConcatenation(@NonNull String concatenation)
   {
     SharedPreferences prefs = PreferenceManager
-        .getDefaultSharedPreferences(MwmApplication.from(context));
+        .getDefaultSharedPreferences(MwmApplication.get());
     prefs.edit().putString(PREFS_WHATS_NEW_TITLE_CONCATENATION, concatenation).apply();
   }
 
-  public static boolean isCatalogCategoriesHeaderClosed(@NonNull Context context)
+  public static boolean isCatalogCategoriesHeaderClosed()
   {
-    return MwmApplication.prefs(context)
+    return MwmApplication.prefs()
                          .getBoolean(PREFS_CATALOG_CATEGORIES_HEADER_CLOSED, false);
   }
 
-  public static void setCatalogCategoriesHeaderClosed(@NonNull Context context, boolean value)
+  public static void setCatalogCategoriesHeaderClosed(boolean value)
   {
-    MwmApplication.prefs(context)
+    MwmApplication.prefs()
                   .edit()
                   .putBoolean(PREFS_CATALOG_CATEGORIES_HEADER_CLOSED, value)
                   .apply();
   }
 
-  public static int getLastVisibleBookmarkCategoriesPage(@NonNull Context context)
+  public static int getLastVisibleBookmarkCategoriesPage()
   {
-    return MwmApplication.prefs(context)
+    return MwmApplication.prefs()
                          .getInt(PREFS_BOOKMARK_CATEGORIES_LAST_VISIBLE_PAGE,
                                  BookmarksPageFactory.PRIVATE.ordinal());
   }
 
-  public static void setLastVisibleBookmarkCategoriesPage(@NonNull Context context, int pageIndex)
+  public static void setLastVisibleBookmarkCategoriesPage(int pageIndex)
   {
-    MwmApplication.prefs(context)
+    MwmApplication.prefs()
                   .edit()
                   .putInt(PREFS_BOOKMARK_CATEGORIES_LAST_VISIBLE_PAGE, pageIndex)
                   .apply();
   }
 
-  public static boolean isTermOfUseAgreementConfirmed(@NonNull Context context)
+  public static boolean isTermOfUseAgreementConfirmed()
   {
-    return getBoolean(context, USER_AGREEMENT_TERM_OF_USE);
+    return getBoolean(USER_AGREEMENT_TERM_OF_USE);
   }
 
-  public static boolean isPrivacyPolicyAgreementConfirmed(@NonNull Context context)
+  public static boolean isPrivacyPolicyAgreementConfirmed()
   {
-    return getBoolean(context, USER_AGREEMENT_PRIVACY_POLICY);
+    return getBoolean(USER_AGREEMENT_PRIVACY_POLICY);
   }
 
-  public static void putPrivacyPolicyAgreement(@NonNull Context context, boolean isChecked)
+  public static void putPrivacyPolicyAgreement(boolean isChecked)
   {
-    putBoolean(context, USER_AGREEMENT_PRIVACY_POLICY, isChecked);
+    putBoolean(USER_AGREEMENT_PRIVACY_POLICY, isChecked);
   }
 
-  public static void putTermOfUseAgreement(@NonNull Context context, boolean isChecked)
+  public static void putTermOfUseAgreement(boolean isChecked)
   {
-    putBoolean(context, USER_AGREEMENT_TERM_OF_USE, isChecked);
+    putBoolean(USER_AGREEMENT_TERM_OF_USE, isChecked);
   }
 
-  public static boolean shouldShowNewMarkerForLayerMode(@NonNull Context context,
-                                                        @NonNull Mode mode)
+  public static boolean shouldShowNewMarkerForLayerMode(@NonNull Mode mode)
   {
     switch (mode)
     {
@@ -156,55 +153,54 @@ public final class SharedPropertiesUtils
       case ISOLINES:
         return false;
       default:
-        return getBoolean(context, PREFS_SHOULD_SHOW_LAYER_MARKER_FOR + mode.name()
+        return getBoolean(PREFS_SHOULD_SHOW_LAYER_MARKER_FOR + mode.name()
                                                                             .toLowerCase(Locale.ENGLISH),
                           true);
     }
   }
 
-  public static boolean shouldShowNewMarkerForLayerMode(@NonNull Context context, @NonNull String mode)
+  public static boolean shouldShowNewMarkerForLayerMode(@NonNull String mode)
   {
-    return shouldShowNewMarkerForLayerMode(context, Mode.valueOf(mode));
+    return shouldShowNewMarkerForLayerMode(Mode.valueOf(mode));
   }
 
-  public static boolean shouldShowLayerTutorialToast(@NonNull Context context)
+  public static boolean shouldShowLayerTutorialToast()
   {
-    boolean result = getBoolean(context, PREFS_SHOULD_SHOW_LAYER_TUTORIAL_TOAST, true);
-    putBoolean(context, PREFS_SHOULD_SHOW_LAYER_TUTORIAL_TOAST, false);
+    boolean result = getBoolean(PREFS_SHOULD_SHOW_LAYER_TUTORIAL_TOAST, true);
+    putBoolean(PREFS_SHOULD_SHOW_LAYER_TUTORIAL_TOAST, false);
     return result;
   }
 
-  public static boolean shouldShowHowToUseGuidesLayerToast(@NonNull Context context)
+  public static boolean shouldShowHowToUseGuidesLayerToast()
   {
-    boolean result = getBoolean(context, PREFS_SHOULD_SHOW_HOW_TO_USE_GUIDES_LAYER_TOAST, true);
-    putBoolean(context, PREFS_SHOULD_SHOW_HOW_TO_USE_GUIDES_LAYER_TOAST, false);
+    boolean result = getBoolean(PREFS_SHOULD_SHOW_HOW_TO_USE_GUIDES_LAYER_TOAST, true);
+    putBoolean(PREFS_SHOULD_SHOW_HOW_TO_USE_GUIDES_LAYER_TOAST, false);
     return result;
   }
 
-  public static void setLayerMarkerShownForLayerMode(@NonNull Context context, @NonNull Mode mode)
+  public static void setLayerMarkerShownForLayerMode(@NonNull Mode mode)
   {
-    putBoolean(context, PREFS_SHOULD_SHOW_LAYER_MARKER_FOR + mode.name()
-                                                                 .toLowerCase(Locale.ENGLISH), false);
+    putBoolean(PREFS_SHOULD_SHOW_LAYER_MARKER_FOR + mode.name().toLowerCase(Locale.ENGLISH), false);
   }
 
-  public static void setLayerMarkerShownForLayerMode(@NonNull Context context, @NonNull String mode)
+  public static void setLayerMarkerShownForLayerMode(@NonNull String mode)
   {
-    setLayerMarkerShownForLayerMode(context, Mode.valueOf(mode));
+    setLayerMarkerShownForLayerMode(Mode.valueOf(mode));
   }
 
-  private static boolean getBoolean(@NonNull Context context,  @NonNull String key)
+  private static boolean getBoolean(@NonNull String key)
   {
-    return getBoolean(context, key, false);
+    return getBoolean(key, false);
   }
 
-  private static boolean getBoolean(@NonNull Context context,  @NonNull String key, boolean defValue)
+  private static boolean getBoolean(@NonNull String key, boolean defValue)
   {
-    return MwmApplication.prefs(context).getBoolean(key, defValue);
+    return MwmApplication.prefs().getBoolean(key, defValue);
   }
 
-  private static void putBoolean(@NonNull Context context,  @NonNull String key, boolean value)
+  private static void putBoolean(@NonNull String key, boolean value)
   {
-    MwmApplication.prefs(context)
+    MwmApplication.prefs()
                   .edit()
                   .putBoolean(key, value)
                   .apply();

--- a/android/src/com/mapswithme/util/StringUtils.java
+++ b/android/src/com/mapswithme/util/StringUtils.java
@@ -1,6 +1,5 @@
 package com.mapswithme.util;
 
-import android.content.Context;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Pair;
@@ -53,11 +52,10 @@ public class StringUtils
    * Formats size in bytes to "x MB" or "x.x GB" format.
    * Small values rounded to 1 MB without fractions.
    *
-   * @param context context for getString()
    * @param size size in bytes
    * @return formatted string
    */
-  public static String getFileSizeString(@NonNull Context context, long size)
+  public static String getFileSizeString(long size)
   {
     if (size < Constants.GB)
     {
@@ -66,12 +64,12 @@ public class StringUtils
         value = 1;
 
       return String.format(Locale.US, "%1$d %2$s", value,
-                           MwmApplication.from(context).getString(R.string.mb));
+                           MwmApplication.get().getString(R.string.mb));
     }
 
     float value = ((float) size / Constants.GB);
     return String.format(Locale.US, "%1$.1f %2$s", value,
-                         MwmApplication.from(context).getString(R.string.gb));
+                         MwmApplication.get().getString(R.string.gb));
   }
 
   public static boolean isRtl()

--- a/android/src/com/mapswithme/util/ThemeSwitcher.java
+++ b/android/src/com/mapswithme/util/ThemeSwitcher.java
@@ -27,8 +27,8 @@ public enum ThemeSwitcher implements Initializable<Context>
     @Override
     public void run()
     {
-      String nightTheme = MwmApplication.from(mContext).getString(R.string.theme_night);
-      String defaultTheme = MwmApplication.from(mContext).getString(R.string.theme_default);
+      String nightTheme = MwmApplication.get().getString(R.string.theme_night);
+      String defaultTheme = MwmApplication.get().getString(R.string.theme_default);
       String theme = defaultTheme;
 
       if (RoutingController.get().isNavigating())
@@ -117,7 +117,7 @@ public enum ThemeSwitcher implements Initializable<Context>
 
       DownloaderStatusIcon.clearCache();
 
-      Activity a = MwmApplication.backgroundTracker(mContext).getTopActivity();
+      Activity a = MwmApplication.backgroundTracker().getTopActivity();
       if (a != null && !a.isFinishing())
         a.recreate();
     }

--- a/android/src/com/mapswithme/util/UiUtils.java
+++ b/android/src/com/mapswithme/util/UiUtils.java
@@ -23,8 +23,6 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.view.WindowManager;
-import android.view.animation.Animation;
-import android.view.animation.Animation.AnimationListener;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.TextView;
@@ -307,9 +305,9 @@ public final class UiUtils
     return rotation;
   }
 
-  public static boolean isTablet(@NonNull Context context)
+  public static boolean isTablet()
   {
-    return MwmApplication.from(context).getResources().getBoolean(R.bool.tabletLayout);
+    return MwmApplication.get().getResources().getBoolean(R.bool.tabletLayout);
   }
 
   public static int dimen(@NonNull Context context, @DimenRes int id)

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -396,9 +396,9 @@ public class Utils
   }
 
   @Nullable
-  public static String getAdvertisingId(@NonNull Context context)
+  public static String getAdvertisingId()
   {
-    MwmApplication application = MwmApplication.from(context);
+    MwmApplication application = MwmApplication.get();
     ExternalLibrariesMediator mediator = application.getMediator();
     return mediator.getAdvertisingId();
   }
@@ -743,10 +743,9 @@ public class Utils
     return c;
   }
 
-  public static void detachFragmentIfCoreNotInitialized(@NonNull Context context,
-                                                        @NonNull Fragment fragment)
+  public static void detachFragmentIfCoreNotInitialized(@NonNull Fragment fragment)
   {
-    if (MwmApplication.from(context).arePlatformAndCoreInitialized())
+    if (MwmApplication.get().arePlatformAndCoreInitialized())
       return;
 
     FragmentManager manager = fragment.getFragmentManager();

--- a/android/src/com/mapswithme/util/log/LoggerFactory.java
+++ b/android/src/com/mapswithme/util/log/LoggerFactory.java
@@ -72,7 +72,7 @@ public class LoggerFactory
       return false;
     }
 
-    SharedPreferences prefs = MwmApplication.prefs(mApplication);
+    SharedPreferences prefs = MwmApplication.prefs();
     String enableLoggingKey = mApplication.getString(R.string.pref_enable_logging);
     //noinspection ConstantConditions
     return prefs.getBoolean(enableLoggingKey, BuildConfig.BUILD_TYPE.equals("beta"));
@@ -82,7 +82,7 @@ public class LoggerFactory
   {
     Objects.requireNonNull(mApplication);
     nativeToggleCoreDebugLogs(enabled);
-    SharedPreferences prefs = MwmApplication.prefs(mApplication);
+    SharedPreferences prefs = MwmApplication.prefs();
     SharedPreferences.Editor editor = prefs.edit();
     String enableLoggingKey = mApplication.getString(R.string.pref_enable_logging);
     editor.putBoolean(enableLoggingKey, enabled).apply();

--- a/android/src/com/mapswithme/util/sharing/SharingHelper.java
+++ b/android/src/com/mapswithme/util/sharing/SharingHelper.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public enum SharingHelper implements Initializable<Context>
+public enum SharingHelper implements Initializable<Void>
 {
   INSTANCE;
 
@@ -49,9 +49,6 @@ public enum SharingHelper implements Initializable<Context>
 
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
-  private Context mContext;
-  @SuppressWarnings("NotNullFieldNotInitialized")
-  @NonNull
   private SharedPreferences mPrefs;
   private final Map<String, SharingTarget> mItems = new HashMap<>();
 
@@ -59,10 +56,9 @@ public enum SharingHelper implements Initializable<Context>
   private ProgressDialog mProgressDialog;
 
   @Override
-  public void initialize(@Nullable Context context)
+  public void initialize(Void nothing)
   {
-    mContext = context;
-    mPrefs = MwmApplication.from(context).getSharedPreferences(PREFS_STORAGE, Context.MODE_PRIVATE);
+    mPrefs = MwmApplication.get().getSharedPreferences(PREFS_STORAGE, Context.MODE_PRIVATE);
 
     ThreadPool.getStorage().execute(
         () ->
@@ -125,7 +121,7 @@ public enum SharingHelper implements Initializable<Context>
     Set<String> missed = new HashSet<>(mItems.keySet());
 
     Intent it = data.getTargetIntent(null);
-    PackageManager pm = MwmApplication.from(mContext).getPackageManager();
+    PackageManager pm = MwmApplication.get().getPackageManager();
     List<ResolveInfo> rlist = pm.queryIntentActivities(it, 0);
 
     final List<SharingTarget> res = new ArrayList<>(rlist.size());

--- a/android/src/com/mapswithme/util/statistics/MytargetHelper.java
+++ b/android/src/com/mapswithme/util/statistics/MytargetHelper.java
@@ -41,7 +41,7 @@ public final class MytargetHelper
     void onDataReady(@Nullable T data);
   }
 
-  public MytargetHelper(final @NonNull Listener<Void> listener, @NonNull Context context)
+  public MytargetHelper(final @NonNull Listener<Void> listener)
   {
     if (!ConnectionState.INSTANCE.isConnected())
     {
@@ -54,7 +54,7 @@ public final class MytargetHelper
       @Override
       public void run()
       {
-        final boolean showShowcase = getShowcaseSetting(context);
+        final boolean showShowcase = getShowcaseSetting();
 
         if (mCancelled)
           return;
@@ -83,12 +83,12 @@ public final class MytargetHelper
   }
 
   @WorkerThread
-  private static boolean getShowcaseSetting(@NonNull Context context)
+  private static boolean getShowcaseSetting()
   {
-    final long lastCheckMillis = prefs(context).getLong(PREF_CHECK_MILLIS, 0);
+    final long lastCheckMillis = prefs().getLong(PREF_CHECK_MILLIS, 0);
     final long currentMillis = System.currentTimeMillis();
     if (currentMillis - lastCheckMillis < CHECK_INTERVAL_MILLIS)
-      return isShowcaseSwitchedOnServer(context);
+      return isShowcaseSwitchedOnServer();
 
     HttpURLConnection connection = null;
     try
@@ -103,7 +103,7 @@ public final class MytargetHelper
       connection.connect();
 
       final boolean showShowcase = connection.getResponseCode() == HttpURLConnection.HTTP_OK;
-      setShowcaseSwitchedOnServer(showShowcase, context);
+      setShowcaseSwitchedOnServer(showShowcase);
 
       return showShowcase;
     } catch (MalformedURLException ignored)
@@ -181,14 +181,14 @@ public final class MytargetHelper
       mShowcase.handleBannerClick(banner);
   }
 
-  public static boolean isShowcaseSwitchedOnServer(@NonNull Context context)
+  public static boolean isShowcaseSwitchedOnServer()
   {
-    return prefs(context).getBoolean(PREF_CHECK, true);
+    return prefs().getBoolean(PREF_CHECK, true);
   }
 
-  private static void setShowcaseSwitchedOnServer(boolean switchedOn, @NonNull Context context)
+  private static void setShowcaseSwitchedOnServer(boolean switchedOn)
   {
-    prefs(context).edit()
+    prefs().edit()
                   .putLong(PREF_CHECK_MILLIS, System.currentTimeMillis())
                   .putBoolean(PREF_CHECK, switchedOn)
                   .apply();

--- a/android/src/com/mapswithme/util/statistics/Statistics.java
+++ b/android/src/com/mapswithme/util/statistics/Statistics.java
@@ -882,7 +882,7 @@ public enum Statistics implements Initializable<Context>
   @Override
   public void initialize(@Nullable Context context)
   {
-    mEnabled = SharedPropertiesUtils.isStatisticsEnabled(context);
+    mEnabled = SharedPropertiesUtils.isStatisticsEnabled();
     // At the moment we need special handling for Alohalytics to enable/disable logging of events in core C++ code.
     if (mEnabled)
       org.alohalytics.Statistics.enable(context);
@@ -996,13 +996,13 @@ public enum Statistics implements Initializable<Context>
     mMediator.getEventLogger().stopActivity(activity);
   }
 
-  public void setStatEnabled(@NonNull Context context, boolean isEnabled)
+  public void setStatEnabled(boolean isEnabled)
   {
-    SharedPropertiesUtils.setStatisticsEnabled(context, isEnabled);
+    SharedPropertiesUtils.setStatisticsEnabled(isEnabled);
     Config.setStatisticsEnabled(isEnabled);
 
     // We track if user turned on/off statistics to understand data better.
-    trackEvent(EventName.STATISTICS_STATUS_CHANGED + " " + Counters.getInstallFlavor(context),
+    trackEvent(EventName.STATISTICS_STATUS_CHANGED + " " + Counters.getInstallFlavor(),
                params().add(EventParam.ENABLED, String.valueOf(isEnabled)));
   }
 
@@ -1253,9 +1253,9 @@ public enum Statistics implements Initializable<Context>
                    .get());
   }
 
-  public void trackColdStartupInfo(@NonNull Context context)
+  public void trackColdStartupInfo()
   {
-    BatteryState.State state = BatteryState.getState(context);
+    BatteryState.State state = BatteryState.getState();
     final String charging;
     switch (state.getChargingStatus())
     {


### PR DESCRIPTION
Get rid of passing `Context` instance explicitly in cases when `MwmApplication` is accessible because `Application` itself is an instance of `Context`.

Closes #86 