### PR TITLE
[android] Remove data sharing beetween Release/Beta/Debug versions

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -3,9 +3,7 @@
     package="com.mapswithme.maps"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:installLocation="auto"
-    android:sharedUserId="app.omaps"
-    android:sharedUserLabel="@string/shared_user_label">
+    android:installLocation="auto">
 
   <!-- Mentioned MoPub dependencies use 16 API level as a min SDK version, which conflicts
        with our version (15 API), that's why forcible use our version to resolve this conflict -->

--- a/android/res/values/donottranslate.xml
+++ b/android/res/values/donottranslate.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="shared_user_label" translatable="false">OMaps</string>
-
   <!-- App names -->
   <string name="facebook" translatable="false">Facebook</string>
   <string name="twitter" translatable="false">Twitter</string>


### PR DESCRIPTION
Fixes "This app can't be installed" error.

Closes https://github.com/omapsapp/omapsapp/issues/105

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>