### PR TITLE
[android] Update Android NDK to the latest LTS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -160,7 +160,7 @@ configurations.all {
 }
 
 android {
-  ndkVersion = "21.3.6528147"
+  ndkVersion = "21.4.7075529"
   dataBinding {
     enabled = true
   }


### PR DESCRIPTION
Fixes "Requested NDK version 21.3.6528147 did not match the version
21.4.7075529 requested by ndk.dir"

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>