### PR TITLE
[routing] Added type aliases for vector-of-edges.

### DIFF
--- a/base/buffer_vector.hpp
+++ b/base/buffer_vector.hpp
@@ -71,7 +71,7 @@ public:
     resize(n, c);
   }
 
-  explicit buffer_vector(std::initializer_list<T> const & initList) : m_size(0)
+  buffer_vector(std::initializer_list<T> const & initList) : m_size(0)
   {
     assign(initList.begin(), initList.end());
   }
@@ -133,6 +133,24 @@ public:
       }
       m_static[m_size++] = *beg++;
     }
+  }
+
+  void append(size_t count, T const & c)
+  {
+    if (!IsDynamic())
+    {
+      size_t const newSize = count + m_size;
+      if (newSize <= N)
+      {
+        while (m_size < newSize)
+          m_static[m_size++] = c;
+        return;
+      }
+      else
+        SwitchToDynamic();
+    }
+
+    m_dynamic.insert(m_dynamic.end(), count, c);
   }
 
   template <typename TIt>
@@ -425,6 +443,7 @@ public:
     }
     resize(std::distance(begin(), first));
   }
+  void erase(iterator it) { erase(it, it + 1); }
 
 private:
   void SwitchToDynamic()

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -207,16 +207,21 @@ public:
     return m_graph.GetPoint(s, forward);
   }
 
+  using SegmentEdgeListT = routing::IndexGraph::SegmentEdgeListT;
+  using EdgeListT = SegmentEdgeListT;
   void GetEdgesList(routing::Segment const & child, bool isOutgoing,
-                    vector<routing::SegmentEdge> & edges)
+                    SegmentEdgeListT & edges)
   {
     m_graph.GetEdgeList(child, isOutgoing, true /* useRoutingOptions */, edges);
   }
 
+  using JointEdgeListT = routing::IndexGraph::JointEdgeListT;
+  using WeightListT = routing::IndexGraph::WeightListT;
+
   void GetEdgeList(
       routing::astar::VertexData<routing::JointSegment, routing::RouteWeight> const & vertexData,
-      routing::Segment const & parent, bool isOutgoing, vector<routing::JointEdge> & edges,
-      vector<routing::RouteWeight> & parentWeights) const
+      routing::Segment const & parent, bool isOutgoing, JointEdgeListT & edges,
+      WeightListT & parentWeights) const
   {
     CHECK(m_AStarParents, ());
     return m_graph.GetEdgeList(vertexData.m_vertex, parent, isOutgoing, edges, parentWeights,

--- a/openlr/candidate_paths_getter.cpp
+++ b/openlr/candidate_paths_getter.cpp
@@ -104,10 +104,13 @@ void CandidatePathsGetter::GetStartLines(vector<m2::PointD> const & points, bool
 {
   for (auto const & pc : points)
   {
+    Graph::EdgeListT tmp;
     if (!isLastPoint)
-      m_graph.GetOutgoingEdges(geometry::PointWithAltitude(pc, 0 /* altitude */), edges);
+      m_graph.GetOutgoingEdges(geometry::PointWithAltitude(pc, 0 /* altitude */), tmp);
     else
-      m_graph.GetIngoingEdges(geometry::PointWithAltitude(pc, 0 /* altitude */), edges);
+      m_graph.GetIngoingEdges(geometry::PointWithAltitude(pc, 0 /* altitude */), tmp);
+
+    edges.insert(edges.end(), tmp.begin(), tmp.end());
   }
 
   // Same edges may start on different points if those points are close enough.
@@ -145,7 +148,7 @@ void CandidatePathsGetter::GetAllSuitablePaths(Graph::EdgeVector const & startLi
 
     ASSERT_LESS(u->m_distanceM + currentEdgeLen, bearDistM, ());
 
-    Graph::EdgeVector edges;
+    Graph::EdgeListT edges;
     if (!isLastPoint)
       m_graph.GetOutgoingEdges(currentEdge.GetEndJunction(), edges);
     else

--- a/openlr/decoded_path.cpp
+++ b/openlr/decoded_path.cpp
@@ -102,7 +102,7 @@ void WriteAsMappingForSpark(std::ostream & ost, std::vector<DecodedPath> const &
 
     auto const kFieldSep = '-';
     auto const kSegmentSep = '=';
-    for (auto it = begin(p.m_path); it != end(p.m_path); ++it)
+    for (auto it = std::begin(p.m_path); it != std::end(p.m_path); ++it)
     {
       auto const & fid = it->GetFeatureId();
       ost << fid.m_mwmId.GetInfo()->GetCountryName()
@@ -111,7 +111,7 @@ void WriteAsMappingForSpark(std::ostream & ost, std::vector<DecodedPath> const &
           << kFieldSep << (it->IsForward() ? "fwd" : "bwd")
           << kFieldSep << mercator::DistanceOnEarth(GetStart(*it), GetEnd(*it));
 
-      if (next(it) != end(p.m_path))
+      if (std::next(it) != std::end(p.m_path))
         ost << kSegmentSep;
     }
     ost << std::endl;
@@ -144,7 +144,7 @@ void PathFromXML(pugi::xml_node const & node, DataSource const & dataSource, Pat
 
 void PathToXML(Path const & path, pugi::xml_node & node)
 {
-  for (auto const e : path)
+  for (auto const & e : path)
   {
     auto edge = node.append_child("RoadEdge");
 

--- a/openlr/graph.cpp
+++ b/openlr/graph.cpp
@@ -16,12 +16,12 @@ namespace openlr
 namespace
 {
 using EdgeGetter = void (IRoadGraph::*)(geometry::PointWithAltitude const &,
-                                        RoadGraphBase::EdgeVector &) const;
+                                        RoadGraphBase::EdgeListT &) const;
 
 void GetRegularEdges(geometry::PointWithAltitude const & junction, IRoadGraph const & graph,
                      EdgeGetter const edgeGetter,
-                     map<openlr::Graph::Junction, Graph::EdgeVector> & cache,
-                     Graph::EdgeVector & edges)
+                     Graph::EdgeCacheT & cache,
+                     Graph::EdgeListT & edges)
 {
   auto const it = cache.find(junction);
   if (it == end(cache))
@@ -43,24 +43,24 @@ Graph::Graph(DataSource const & dataSource, shared_ptr<CarModelFactory> carModel
 {
 }
 
-void Graph::GetOutgoingEdges(Junction const & junction, EdgeVector & edges)
+void Graph::GetOutgoingEdges(Junction const & junction, EdgeListT & edges)
 {
   GetRegularOutgoingEdges(junction, edges);
   m_graph.GetFakeOutgoingEdges(junction, edges);
 }
 
-void Graph::GetIngoingEdges(Junction const & junction, EdgeVector & edges)
+void Graph::GetIngoingEdges(Junction const & junction, EdgeListT & edges)
 {
   GetRegularIngoingEdges(junction, edges);
   m_graph.GetFakeIngoingEdges(junction, edges);
 }
 
-void Graph::GetRegularOutgoingEdges(Junction const & junction, EdgeVector & edges)
+void Graph::GetRegularOutgoingEdges(Junction const & junction, EdgeListT & edges)
 {
   GetRegularEdges(junction, m_graph, &IRoadGraph::GetRegularOutgoingEdges, m_outgoingCache, edges);
 }
 
-void Graph::GetRegularIngoingEdges(Junction const & junction, EdgeVector & edges)
+void Graph::GetRegularIngoingEdges(Junction const & junction, EdgeListT & edges)
 {
   GetRegularEdges(junction, m_graph, &IRoadGraph::GetRegularIngoingEdges, m_ingoingCache, edges);
 }

--- a/openlr/graph.hpp
+++ b/openlr/graph.hpp
@@ -25,22 +25,23 @@ class Graph
 {
 public:
   using Edge = routing::Edge;
+  using EdgeListT = routing::FeaturesRoadGraph::EdgeListT;
   using EdgeVector = routing::FeaturesRoadGraph::EdgeVector;
   using Junction = geometry::PointWithAltitude;
 
   Graph(DataSource const & dataSource, std::shared_ptr<routing::CarModelFactory> carModelFactory);
 
   // Appends edges such as that edge.GetStartJunction() == junction to the |edges|.
-  void GetOutgoingEdges(geometry::PointWithAltitude const & junction, EdgeVector & edges);
+  void GetOutgoingEdges(geometry::PointWithAltitude const & junction, EdgeListT & edges);
   // Appends edges such as that edge.GetEndJunction() == junction to the |edges|.
-  void GetIngoingEdges(geometry::PointWithAltitude const & junction, EdgeVector & edges);
+  void GetIngoingEdges(geometry::PointWithAltitude const & junction, EdgeListT & edges);
 
   // Appends edges such as that edge.GetStartJunction() == junction and edge.IsFake() == false
   // to the |edges|.
-  void GetRegularOutgoingEdges(Junction const & junction, EdgeVector & edges);
+  void GetRegularOutgoingEdges(Junction const & junction, EdgeListT & edges);
   // Appends edges such as that edge.GetEndJunction() == junction and edge.IsFale() == false
   // to the |edges|.
-  void GetRegularIngoingEdges(Junction const & junction, EdgeVector & edges);
+  void GetRegularIngoingEdges(Junction const & junction, EdgeListT & edges);
 
   void FindClosestEdges(m2::PointD const & point, uint32_t const count,
                         std::vector<std::pair<Edge, Junction>> & vicinities) const;
@@ -52,9 +53,9 @@ public:
 
   void GetFeatureTypes(FeatureID const & featureId, feature::TypesHolder & types) const;
 
+  using EdgeCacheT = std::map<Junction, EdgeListT>;
 private:
   routing::FeaturesRoadGraph m_graph;
-  std::map<Junction, EdgeVector> m_outgoingCache;
-  std::map<Junction, EdgeVector> m_ingoingCache;
+  EdgeCacheT m_outgoingCache, m_ingoingCache;
 };
 }  // namespace openlr

--- a/openlr/openlr_decoder.cpp
+++ b/openlr/openlr_decoder.cpp
@@ -97,7 +97,7 @@ bool IsRealVertex(m2::PointD const & p, FeatureID const & fid, DataSource const 
       },
       FeatureType::BEST_GEOMETRY);
   return matched;
-};
+}
 
 void ExpandFake(Graph::EdgeVector & path, Graph::EdgeVector::iterator edgeIt, DataSource const & dataSource,
                 Graph & g)
@@ -105,7 +105,7 @@ void ExpandFake(Graph::EdgeVector & path, Graph::EdgeVector::iterator edgeIt, Da
   if (!edgeIt->IsFake())
     return;
 
-  Graph::EdgeVector edges;
+  Graph::EdgeListT edges;
   bool startIsFake = true;
   if (IsRealVertex(edgeIt->GetStartPoint(), edgeIt->GetFeatureId(), dataSource))
   {
@@ -153,16 +153,16 @@ void ExpandFake(Graph::EdgeVector & path, Graph::EdgeVector::iterator edgeIt, Da
     *edgeIt = *it;
   else
     path.erase(edgeIt);
-};
+}
 
 void ExpandFakes(DataSource const & dataSource, Graph & g, Graph::EdgeVector & path)
 {
   ASSERT(!path.empty(), ());
 
-  ExpandFake(path, begin(path), dataSource, g);
+  ExpandFake(path, std::begin(path), dataSource, g);
   if (path.empty())
     return;
-  ExpandFake(path, --end(path), dataSource, g);
+  ExpandFake(path, std::end(path) - 1, dataSource, g);
 }
 
 // Returns an iterator pointing to the first edge that should not be cut off.

--- a/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
@@ -201,7 +201,7 @@ public:
 
   std::vector<m2::PointD> GetReachablePoints(m2::PointD const & p) const override
   {
-    routing::FeaturesRoadGraph::EdgeVector edges;
+    routing::FeaturesRoadGraph::EdgeListT edges;
     m_roadGraph.GetOutgoingEdges(geometry::PointWithAltitude(p, geometry::kDefaultAltitudeMeters),
                                  edges);
 

--- a/openlr/paths_connector.cpp
+++ b/openlr/paths_connector.cpp
@@ -169,7 +169,7 @@ bool PathsConnector::FindShortestPath(Graph::Edge const & from, Graph::Edge cons
       return true;
     }
 
-    Graph::EdgeVector edges;
+    Graph::EdgeListT edges;
     m_graph.GetOutgoingEdges(u.GetEndJunction(), edges);
     for (auto const & e : edges)
     {

--- a/openlr/score_candidate_paths_getter.cpp
+++ b/openlr/score_candidate_paths_getter.cpp
@@ -56,7 +56,7 @@ double DifferenceInDeg(double a1, double a2)
   return diff;
 }
 
-void EdgeSortUniqueByStartAndEndPoints(Graph::EdgeVector & edges)
+void EdgeSortUniqueByStartAndEndPoints(Graph::EdgeListT & edges)
 {
   base::SortUnique(
       edges,
@@ -185,7 +185,7 @@ void ScoreCandidatePathsGetter::GetAllSuitablePaths(ScoreEdgeVec const & startLi
 
     CHECK_LESS(u->m_distanceM + currentEdgeLen, bearDistM, ());
 
-    Graph::EdgeVector edges;
+    Graph::EdgeListT edges;
     if (!isLastPoint)
       m_graph.GetOutgoingEdges(currentEdge.GetEndJunction(), edges);
     else

--- a/openlr/score_candidate_points_getter.cpp
+++ b/openlr/score_candidate_points_getter.cpp
@@ -59,7 +59,7 @@ void ScoreCandidatePointsGetter::GetJunctionPointCandidates(m2::PointD const & p
 
   for (auto const & pc : pointCandidates)
   {
-    Graph::EdgeVector edges;
+    Graph::EdgeListT edges;
     if (!isLastPoint)
       m_graph.GetOutgoingEdges(geometry::PointWithAltitude(pc.m_point, 0 /* altitude */), edges);
     else
@@ -94,10 +94,10 @@ void ScoreCandidatePointsGetter::EnrichWithProjectionPoints(m2::PointD const & p
 
 bool ScoreCandidatePointsGetter::IsJunction(m2::PointD const & p)
 {
-  Graph::EdgeVector outgoing;
+  Graph::EdgeListT outgoing;
   m_graph.GetRegularOutgoingEdges(geometry::PointWithAltitude(p, 0 /* altitude */), outgoing);
 
-  Graph::EdgeVector ingoing;
+  Graph::EdgeListT ingoing;
   m_graph.GetRegularIngoingEdges(geometry::PointWithAltitude(p, 0 /* altitude */), ingoing);
 
   // Note. At mwm borders the size of |ids| may be bigger than two in case of straight

--- a/openlr/score_paths_connector.cpp
+++ b/openlr/score_paths_connector.cpp
@@ -271,7 +271,7 @@ bool ScorePathsConnector::FindShortestPath(Graph::Edge const & from, Graph::Edge
       return true;
     }
 
-    Graph::EdgeVector edges;
+    Graph::EdgeListT edges;
     m_graph.GetOutgoingEdges(stateEdge.GetEndJunction(), edges);
     for (auto const & edge : edges)
     {

--- a/openlr/score_types.hpp
+++ b/openlr/score_types.hpp
@@ -48,7 +48,7 @@ using ScoreEdgeVec = std::vector<ScoreEdge>;
 
 struct ScorePath
 {
-  ScorePath(Score score, EdgeVector && path) : m_score(score), m_path(move(path)) {}
+  ScorePath(Score score, EdgeVector && path) : m_score(score), m_path(std::move(path)) {}
 
   Score m_score;
   EdgeVector m_path;

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -20,6 +20,8 @@ set(
   base/followed_polyline.cpp
   base/followed_polyline.hpp
   base/routing_result.hpp
+  base/small_list.hpp
+  base/small_list.cpp
   car_directions.cpp
   car_directions.hpp
   checkpoint_predictor.cpp

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -341,7 +341,7 @@ private:
       parent.insert_or_assign(to, from);
     }
 
-    void GetAdjacencyList(State const & state, std::vector<Edge> & adj)
+    void GetAdjacencyList(State const & state, typename Graph::EdgeListT & adj)
     {
       auto const realDistance = state.distance + pS - state.heuristic;
       astar::VertexData const data(state.vertex, realDistance);
@@ -399,7 +399,7 @@ void AStarAlgorithm<Vertex, Edge, Weight>::PropagateWave(
   context.SetDistance(startVertex, kZeroDistance);
   queue.push(State(startVertex, kZeroDistance));
 
-  std::vector<Edge> adj;
+  typename Graph::EdgeListT adj;
 
   while (!queue.empty())
   {
@@ -599,7 +599,7 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(P & params,
     return Result::OK;
   };
 
-  std::vector<Edge> adj;
+  typename Graph::EdgeListT adj;
 
   // It is not necessary to check emptiness for both queues here
   // because if we have not found a path by the time one of the

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -2,6 +2,9 @@
 
 #include "routing/base/astar_weight.hpp"
 #include "routing/base/astar_vertex_data.hpp"
+#include "routing/base/small_list.hpp"
+
+#include "base/buffer_vector.hpp"
 
 #include <map>
 #include <vector>
@@ -20,12 +23,14 @@ public:
 
   using Parents = ska::bytell_hash_map<Vertex, Vertex>;
 
+  using EdgeListT = SmallList<Edge>;
+
   virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) = 0;
 
   virtual void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                                    std::vector<Edge> & edges) = 0;
+                                    EdgeListT & edges) = 0;
   virtual void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                                   std::vector<Edge> & edges) = 0;
+                                   EdgeListT & edges) = 0;
 
   virtual void SetAStarParents(bool forward, Parents & parents);
   virtual void DropAStarParents();

--- a/routing/base/bfs.hpp
+++ b/routing/base/bfs.hpp
@@ -53,7 +53,7 @@ void BFS<Graph>::Run(Vertex const & start, bool isOutgoing,
   std::queue<Vertex> queue;
   queue.emplace(start);
 
-  std::vector<Edge> edges;
+  typename Graph::EdgeListT edges;
   while (!queue.empty())
   {
     Vertex const current = queue.front();

--- a/routing/base/small_list.cpp
+++ b/routing/base/small_list.cpp
@@ -1,0 +1,27 @@
+#include "small_list.hpp"
+
+#include "base/logging.hpp"
+
+namespace routing
+{
+namespace impl
+{
+
+std::map<char const *, Statistics::Info> Statistics::s_map;
+
+void Statistics::Add(char const * name, size_t val)
+{
+  auto & e = s_map[name];
+  ++e.m_count;
+  e.m_sum += val;
+  e.m_max = std::max(val, e.m_max);
+}
+
+void Statistics::Dump()
+{
+  for (auto const & e : s_map)
+    LOG(LINFO, (e.first, ": count = ", e.second.m_count, "; max = ", e.second.m_max, "; avg = ", e.second.m_sum / double(e.second.m_count)));
+}
+
+} // namespace impl
+} // namesapce routing

--- a/routing/base/small_list.hpp
+++ b/routing/base/small_list.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include "base/buffer_vector.hpp"
+
+#include <map>
+
+namespace routing
+{
+namespace impl
+{
+
+class Statistics
+{
+  struct Info
+  {
+    size_t m_sum = 0;
+    size_t m_count = 0;
+    size_t m_max = 0;
+  };
+
+  static std::map<char const *, Info> s_map;
+
+public:
+  static void Add(char const * name, size_t val);
+  static void Dump();
+};
+
+} // namespace impl
+
+template <class T> class SmallList : public buffer_vector<T, 8>
+{
+  using BaseT = buffer_vector<T, 8>;
+
+public:
+  using BaseT::BaseT;
+
+  /// @todo Use in Generator only.
+  /*
+  void clear()
+  {
+    impl::Statistics::Add(typeid(T).name(), BaseT::size());
+    BaseT::clear();
+  }
+
+  ~SmallList()
+  {
+    impl::Statistics::Add(typeid(T).name(), BaseT::size());
+  }
+  */
+};
+
+} // namesapce routing

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -3,10 +3,13 @@
 #include "routing/cross_mwm_ids.hpp"
 #include "routing/segment.hpp"
 
+#include "routing/base/small_list.hpp"
+
 #include "geometry/mercator.hpp"
 #include "geometry/point2d.hpp"
 
 #include "base/assert.hpp"
+#include "base/buffer_vector.hpp"
 
 #include <cmath>
 #include <cstdint>
@@ -146,7 +149,9 @@ public:
     return &segment;
   }
 
-  void GetOutgoingEdgeList(Segment const & segment, std::vector<SegmentEdge> & edges) const
+  using EdgeListT = SmallList<SegmentEdge>;
+
+  void GetOutgoingEdgeList(Segment const & segment, EdgeListT & edges) const
   {
     auto const & transition = GetTransition(segment);
     CHECK_NOT_EQUAL(transition.m_enterIdx, connector::kFakeIndex, ());
@@ -158,7 +163,7 @@ public:
     }
   }
 
-  void GetIngoingEdgeList(Segment const & segment, std::vector<SegmentEdge> & edges) const
+  void GetIngoingEdgeList(Segment const & segment, EdgeListT & edges) const
   {
     auto const & transition = GetTransition(segment);
     CHECK_NOT_EQUAL(transition.m_exitIdx, connector::kFakeIndex, ());
@@ -273,7 +278,7 @@ private:
   friend class CrossMwmConnectorSerializer;
 
   void AddEdge(Segment const & segment, connector::Weight weight,
-               std::vector<SegmentEdge> & edges) const
+               EdgeListT & edges) const
   {
     // @TODO Double and uint32_t are compared below. This comparison should be fixed.
     if (weight != connector::kNoRoute)

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -128,7 +128,7 @@ void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment>
     CHECK_NOT_EQUAL(s.GetMwmId(), t.GetMwmId(), ());
 }
 
-void CrossMwmGraph::GetOutgoingEdgeList(Segment const & enter, vector<SegmentEdge> & edges)
+void CrossMwmGraph::GetOutgoingEdgeList(Segment const & enter, EdgeListT & edges)
 {
   ASSERT(
       IsTransition(enter, false /* isEnter */),
@@ -148,7 +148,7 @@ void CrossMwmGraph::GetOutgoingEdgeList(Segment const & enter, vector<SegmentEdg
     m_crossMwmIndexGraph.GetOutgoingEdgeList(enter, edges);
 }
 
-void CrossMwmGraph::GetIngoingEdgeList(Segment const & exit, vector<SegmentEdge> & edges)
+void CrossMwmGraph::GetIngoingEdgeList(Segment const & exit, EdgeListT & edges)
 {
   ASSERT(
     IsTransition(exit, true /* isEnter */),

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -81,15 +81,17 @@ public:
   /// If not, |twins| could be emply after a GetTwins(...) call.
   void GetTwins(Segment const & s, bool isOutgoing, std::vector<Segment> & twins);
 
+  using EdgeListT = CrossMwmIndexGraph<base::GeoObjectId>::EdgeListT;
+
   /// \brief Fills |edges| with edges outgoing from |s|.
   /// |s| should be an enter transition segment, |edges| is filled with all edges starting from |s|
   /// and ending at all reachable exit transition segments of the mwm of |s|.
   /// Weight of each edge is equal to weight of the route form |s| to |SegmentEdge::m_target|.
   /// Getting ingoing edges is not supported because we do not have enough information
   /// to calculate |segment| weight.
-  void GetOutgoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges);
+  void GetOutgoingEdgeList(Segment const & s, EdgeListT & edges);
 
-  void GetIngoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges);
+  void GetIngoingEdgeList(Segment const & s, EdgeListT & edges);
 
   void Clear();
 

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -156,13 +156,15 @@ public:
     }
   }
 
-  void GetOutgoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges)
+  using EdgeListT = typename CrossMwmConnector<CrossMwmId>::EdgeListT;
+
+  void GetOutgoingEdgeList(Segment const & s, EdgeListT & edges)
   {
     CrossMwmConnector<CrossMwmId> const & c = GetCrossMwmConnectorWithWeights(s.GetMwmId());
     c.GetOutgoingEdgeList(s, edges);
   }
 
-  void GetIngoingEdgeList(Segment const & s, std::vector<SegmentEdge> & edges)
+  void GetIngoingEdgeList(Segment const & s, EdgeListT & edges)
   {
     CrossMwmConnector<CrossMwmId> const & c = GetCrossMwmConnectorWithWeights(s.GetMwmId());
     c.GetIngoingEdgeList(s, edges);

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -68,7 +68,7 @@ void DirectionsEngine::LoadPathAttributes(FeatureID const & featureId,
   pathSegment.m_onRoundabout = ftypes::IsRoundAboutChecker::Instance()(*ft);
 }
 
-void DirectionsEngine::GetSegmentRangeAndAdjacentEdges(IRoadGraph::EdgeVector const & outgoingEdges,
+void DirectionsEngine::GetSegmentRangeAndAdjacentEdges(IRoadGraph::EdgeListT const & outgoingEdges,
                                                        Edge const & inEdge, uint32_t startSegId,
                                                        uint32_t endSegId,
                                                        SegmentRange & segmentRange,
@@ -137,8 +137,8 @@ void DirectionsEngine::GetSegmentRangeAndAdjacentEdges(IRoadGraph::EdgeVector co
 
 void DirectionsEngine::GetEdges(IndexRoadGraph const & graph,
                                 geometry::PointWithAltitude const & currJunction,
-                                bool isCurrJunctionFinish, IRoadGraph::EdgeVector & outgoing,
-                                IRoadGraph::EdgeVector & ingoing)
+                                bool isCurrJunctionFinish, IRoadGraph::EdgeListT & outgoing,
+                                IRoadGraph::EdgeListT & ingoing)
 {
   // Note. If |currJunction| is a finish the outgoing edges
   // from finish are not important for turn generation.
@@ -169,8 +169,8 @@ void DirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
     geometry::PointWithAltitude const & prevJunction = path[i - 1];
     geometry::PointWithAltitude const & currJunction = path[i];
 
-    IRoadGraph::EdgeVector outgoingEdges;
-    IRoadGraph::EdgeVector ingoingEdges;
+    IRoadGraph::EdgeListT outgoingEdges;
+    IRoadGraph::EdgeListT ingoingEdges;
     bool const isCurrJunctionFinish = (i + 1 == pathSize);
     GetEdges(graph, currJunction, isCurrJunctionFinish, outgoingEdges, ingoingEdges);
 

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -50,7 +50,7 @@ public:
 protected:
   FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
   void LoadPathAttributes(FeatureID const & featureId, LoadedPathSegment & pathSegment);
-  void GetSegmentRangeAndAdjacentEdges(IRoadGraph::EdgeVector const & outgoingEdges,
+  void GetSegmentRangeAndAdjacentEdges(IRoadGraph::EdgeListT const & outgoingEdges,
                                        Edge const & inEdge, uint32_t startSegId, uint32_t endSegId,
                                        SegmentRange & segmentRange,
                                        turns::TurnCandidates & outgoingTurns);
@@ -62,8 +62,8 @@ protected:
                                            base::Cancellable const & cancellable);
 
   void GetEdges(IndexRoadGraph const & graph, geometry::PointWithAltitude const & currJunction,
-                bool isCurrJunctionFinish, IRoadGraph::EdgeVector & outgoing,
-                IRoadGraph::EdgeVector & ingoing);
+                bool isCurrJunctionFinish, IRoadGraph::EdgeListT & outgoing,
+                IRoadGraph::EdgeListT & ingoing);
 
   AdjacentEdgesMap m_adjacentEdges;
   TUnpackedPathSegments m_pathSegments;

--- a/routing/directions_engine_helpers.cpp
+++ b/routing/directions_engine_helpers.cpp
@@ -58,8 +58,8 @@ geometry::PointWithAltitude RoutingEngineResult::GetEndPoint() const
   return m_routeEdges.back().GetEndJunction();
 }
 
-bool IsJoint(IRoadGraph::EdgeVector const & ingoingEdges,
-             IRoadGraph::EdgeVector const & outgoingEdges, Edge const & ingoingRouteEdge,
+bool IsJoint(IRoadGraph::EdgeListT const & ingoingEdges,
+             IRoadGraph::EdgeListT const & outgoingEdges, Edge const & ingoingRouteEdge,
              Edge const & outgoingRouteEdge, bool isCurrJunctionFinish, bool isInEdgeReal)
 {
   // When feature id is changed at a junction this junction should be considered as a joint.

--- a/routing/directions_engine_helpers.hpp
+++ b/routing/directions_engine_helpers.hpp
@@ -51,7 +51,7 @@ private:
 /// \returns false if the junction is an internal point of feature segment and can be considered as
 /// a part of LoadedPathSegment and returns true if the junction should be considered as a beginning
 /// of a new LoadedPathSegment.
-bool IsJoint(IRoadGraph::EdgeVector const & ingoingEdges,
-             IRoadGraph::EdgeVector const & outgoingEdges, Edge const & ingoingRouteEdge,
+bool IsJoint(IRoadGraph::EdgeListT const & ingoingEdges,
+             IRoadGraph::EdgeListT const & outgoingEdges, Edge const & ingoingRouteEdge,
              Edge const & outgoingRouteEdge, bool isCurrJunctionFinish, bool isInEdgeReal);
 }  // namespace routing

--- a/routing/dummy_world_graph.hpp
+++ b/routing/dummy_world_graph.hpp
@@ -25,15 +25,15 @@ public:
 
   void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
                    bool useRoutingOptions, bool useAccessConditional,
-                   std::vector<SegmentEdge> & edges) override
+                   SegmentEdgeListT & edges) override
   {
     UNREACHABLE();
   }
 
   void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & vertexData,
                    Segment const & segment, bool isOutgoing, bool useAccessConditional,
-                   std::vector<JointEdge> & edges,
-                   std::vector<RouteWeight> & parentWeights) override
+                   JointEdgeListT & edges,
+                   WeightListT & parentWeights) override
   {
     UNREACHABLE();
   }

--- a/routing/guides_graph.cpp
+++ b/routing/guides_graph.cpp
@@ -41,7 +41,7 @@ double GuidesGraph::CalcSegmentTimeS(LatLonWithAltitude const & point1,
 }
 
 void GuidesGraph::GetEdgeList(Segment const & segment, bool isOutgoing,
-                              std::vector<SegmentEdge> & edges,
+                              EdgeListT & edges,
                               RouteWeight const & prevWeight) const
 {
   auto const it = m_segments.find(segment);

--- a/routing/guides_graph.hpp
+++ b/routing/guides_graph.hpp
@@ -4,6 +4,8 @@
 #include "routing/latlon_with_altitude.hpp"
 #include "routing/segment.hpp"
 
+#include "routing/base/small_list.hpp"
+
 #include "routing_common/num_mwm_id.hpp"
 
 #include "geometry/point2d.hpp"
@@ -46,7 +48,8 @@ public:
   FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point,
                             geometry::PointWithAltitude const & projection) const;
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges,
+  using EdgeListT = SmallList<SegmentEdge>;
+  void GetEdgeList(Segment const & segment, bool isOutgoing, EdgeListT & edges,
                    RouteWeight const & prevWeight) const;
   routing::LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;
   RouteWeight CalcSegmentWeight(Segment const & segment) const;

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -3,6 +3,7 @@
 #include "routing/base/astar_algorithm.hpp"
 #include "routing/base/astar_graph.hpp"
 #include "routing/base/astar_vertex_data.hpp"
+
 #include "routing/edge_estimator.hpp"
 #include "routing/geometry.hpp"
 #include "routing/joint.hpp"
@@ -43,23 +44,29 @@ public:
   
   using Restrictions = std::unordered_map<uint32_t, std::vector<std::vector<uint32_t>>>;
 
+  using SegmentEdgeListT = SmallList<SegmentEdge>;
+  using JointEdgeListT = SmallList<JointEdge>;
+  using WeightListT = SmallList<RouteWeight>;
+  using SegmentListT = SmallList<Segment>;
+  using PointIdListT = SmallList<uint32_t>;
+
   IndexGraph() = default;
   IndexGraph(std::shared_ptr<Geometry> geometry, std::shared_ptr<EdgeEstimator> estimator,
              RoutingOptions routingOptions = RoutingOptions());
 
   // Put outgoing (or ingoing) egdes for segment to the 'edges' vector.
   void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
-                   bool useRoutingOptions, std::vector<SegmentEdge> & edges,
+                   bool useRoutingOptions, SegmentEdgeListT & edges,
                    Parents<Segment> const & parents = {});
   void GetEdgeList(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
-                   std::vector<SegmentEdge> & edges,
+                   SegmentEdgeListT & edges,
                    Parents<Segment> const & parents = {});
 
   void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
-                   Segment const & parent, bool isOutgoing, std::vector<JointEdge> & edges,
-                   std::vector<RouteWeight> & parentWeights, Parents<JointSegment> & parents);
+                   Segment const & parent, bool isOutgoing, JointEdgeListT & edges,
+                   WeightListT & parentWeights, Parents<JointSegment> & parents);
   void GetEdgeList(JointSegment const & parentJoint, Segment const & parent, bool isOutgoing,
-                   std::vector<JointEdge> & edges, std::vector<RouteWeight> & parentWeights,
+                   JointEdgeListT & edges, WeightListT & parentWeights,
                    Parents<JointSegment> & parents);
 
   std::optional<JointEdge> GetJointEdgeByLastPoint(Segment const & parent,
@@ -108,8 +115,8 @@ public:
 
   bool IsJoint(RoadPoint const & roadPoint) const;
   bool IsJointOrEnd(Segment const & segment, bool fromStart);
-  void GetLastPointsForJoint(std::vector<Segment> const & children, bool isOutgoing,
-                             std::vector<uint32_t> & lastPoints);
+  void GetLastPointsForJoint(SegmentListT const & children, bool isOutgoing,
+                             PointIdListT & lastPoints);
 
   WorldGraphMode GetMode() const;
   ms::LatLon const & GetPoint(Segment const & segment, bool front)
@@ -138,19 +145,19 @@ public:
 private:
   void GetEdgeListImpl(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
                        bool useRoutingOptions, bool useAccessConditional,
-                       std::vector<SegmentEdge> & edges, Parents<Segment> const & parents);
+                       SegmentEdgeListT & edges, Parents<Segment> const & parents);
 
   void GetEdgeListImpl(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                        Segment const & parent, bool isOutgoing, bool useAccessConditional,
-                       std::vector<JointEdge> & edges, std::vector<RouteWeight> & parentWeights,
+                       JointEdgeListT & edges, WeightListT & parentWeights,
                        Parents<JointSegment> & parents);
 
   void GetNeighboringEdges(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
                            RoadPoint const & rp, bool isOutgoing, bool useRoutingOptions,
-                           std::vector<SegmentEdge> & edges, Parents<Segment> const & parents,
+                           SegmentEdgeListT & edges, Parents<Segment> const & parents,
                            bool useAccessConditional);
   void GetNeighboringEdge(astar::VertexData<Segment, RouteWeight> const & fromVertexData,
-                          Segment const & to, bool isOutgoing, std::vector<SegmentEdge> & edges,
+                          Segment const & to, bool isOutgoing, SegmentEdgeListT & edges,
                           Parents<Segment> const & parents, bool useAccessConditional);
 
   struct PenaltyData
@@ -173,15 +180,15 @@ private:
                            std::optional<RouteWeight> const & prevWeight);
 
   void GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId numMwmId,
-                                       bool isOutgoing, std::vector<Segment> & children);
-  void GetSegmentCandidateForJoint(Segment const & parent, bool isOutgoing, std::vector<Segment> & children);
+                                       bool isOutgoing, SegmentListT & children);
+  void GetSegmentCandidateForJoint(Segment const & parent, bool isOutgoing, SegmentListT & children);
   void ReconstructJointSegment(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                                Segment const & parent,
-                               std::vector<Segment> const & firstChildren,
-                               std::vector<uint32_t> const & lastPointIds,
+                               SegmentListT const & firstChildren,
+                               PointIdListT const & lastPointIds,
                                bool isOutgoing,
-                               std::vector<JointEdge> & jointEdges,
-                               std::vector<RouteWeight> & parentWeights,
+                               JointEdgeListT & jointEdges,
+                               WeightListT & parentWeights,
                                Parents<JointSegment> const & parents);
 
   template <typename AccessPositionType>

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -201,7 +201,7 @@ bool IndexGraphStarter::CheckLength(RouteWeight const & weight)
 
 void IndexGraphStarter::GetEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                                      bool isOutgoing, bool useAccessConditional,
-                                     vector<SegmentEdge> & edges) const
+                                     EdgeListT & edges) const
 {
   edges.clear();
   CHECK_NOT_EQUAL(m_graph.GetMode(), WorldGraphMode::LeapsOnly, ());
@@ -556,9 +556,9 @@ void IndexGraphStarter::AddFinish(FakeEnding const & finishEnding, FakeEnding co
   m_finish.FillMwmIds();
 }
 
-void IndexGraphStarter::AddFakeEdges(Segment const & segment, bool isOutgoing, vector<SegmentEdge> & edges) const
+void IndexGraphStarter::AddFakeEdges(Segment const & segment, bool isOutgoing, EdgeListT & edges) const
 {
-  vector<SegmentEdge> fakeEdges;
+  EdgeListT fakeEdges;
   for (auto const & edge : edges)
   {
     for (auto const & s : m_fake.GetFake(edge.GetTarget()))

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -40,6 +40,9 @@ public:
   template <typename VertexType>
   using Parents = IndexGraph::Parents<VertexType>;
 
+  using JointEdgeListT = IndexGraph::JointEdgeListT;
+  using WeightListT = IndexGraph::WeightListT;
+
   friend class FakeEdgesContainer;
 
   static void CheckValidRoute(std::vector<Segment> const & segments);
@@ -103,8 +106,8 @@ public:
   bool CheckLength(RouteWeight const & weight);
 
   void GetEdgeList(astar::VertexData<JointSegment, Weight> const & parentVertexData,
-                   Segment const & segment, bool isOutgoing, std::vector<JointEdge> & edges,
-                   std::vector<RouteWeight> & parentWeights) const
+                   Segment const & segment, bool isOutgoing, JointEdgeListT & edges,
+                   WeightListT & parentWeights) const
   {
     return m_graph.GetEdgeList(parentVertexData, segment, isOutgoing,
                                true /* useAccessConditional */, edges, parentWeights);
@@ -113,13 +116,13 @@ public:
   // AStarGraph overridings:
   // @{
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                            std::vector<Edge> & edges) override
+                            EdgeListT & edges) override
   {
     GetEdgesList(vertexData, true /* isOutgoing */, true /* useAccessConditional */, edges);
   }
 
   void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                           std::vector<Edge> & edges) override
+                           EdgeListT & edges) override
   {
     GetEdgesList(vertexData, false /* isOutgoing */, true /* useAccessConditional */, edges);
   }
@@ -149,7 +152,7 @@ public:
   RouteWeight GetAStarWeightEpsilon() override;
   // @}
 
-  void GetEdgesList(Vertex const & vertex, bool isOutgoing, std::vector<SegmentEdge> & edges) const
+  void GetEdgesList(Vertex const & vertex, bool isOutgoing, EdgeListT & edges) const
   {
     GetEdgesList({vertex, Weight(0.0)}, isOutgoing, false /* useAccessConditional */, edges);
   }
@@ -234,7 +237,7 @@ private:
   Segment GetFakeSegmentAndIncr();
 
   void GetEdgesList(astar::VertexData<Vertex, Weight> const & vertexData, bool isOutgoing,
-                    bool useAccessConditional, std::vector<SegmentEdge> & edges) const;
+                    bool useAccessConditional, EdgeListT & edges) const;
 
   void AddStart(FakeEnding const & startEnding, FakeEnding const & finishEnding,
                 bool strictForward);
@@ -242,7 +245,7 @@ private:
 
   // Adds fake edges of type PartOfReal which correspond real edges from |edges| and are connected
   // to |segment|
-  void AddFakeEdges(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges) const;
+  void AddFakeEdges(Segment const & segment, bool isOutgoing, EdgeListT & edges) const;
 
   // Checks whether ending belongs to pass-through or non-pass-through zone.
   bool EndingPassThroughAllowed(Ending const & ending);

--- a/routing/index_road_graph.hpp
+++ b/routing/index_road_graph.hpp
@@ -26,9 +26,9 @@ public:
 
   // IRoadGraphBase overrides:
   virtual void GetOutgoingEdges(geometry::PointWithAltitude const & junction,
-                                EdgeVector & edges) const override;
+                                EdgeListT & edges) const override;
   virtual void GetIngoingEdges(geometry::PointWithAltitude const & junction,
-                               EdgeVector & edges) const override;
+                               EdgeListT & edges) const override;
   virtual double GetMaxSpeedKMpH() const override;
   virtual void GetEdgeTypes(Edge const & edge, feature::TypesHolder & types) const override;
   virtual void GetJunctionTypes(geometry::PointWithAltitude const & junction,
@@ -37,16 +37,16 @@ public:
   virtual void GetRouteSegments(std::vector<Segment> & segments) const override;
 
 private:
-  void GetEdges(geometry::PointWithAltitude const & junction, bool isOutgoing,
-                EdgeVector & edges) const;
-  std::vector<Segment> const & GetSegments(geometry::PointWithAltitude const & junction,
-                                           bool isOutgoing) const;
+  void GetEdges(geometry::PointWithAltitude const & junction, bool isOutgoing, EdgeListT & edges) const;
+
+  using SegmentListT = SmallList<Segment>;
+  SegmentListT const & GetSegments(geometry::PointWithAltitude const & junction, bool isOutgoing) const;
 
   DataSource & m_dataSource;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
   IndexGraphStarter & m_starter;
   std::vector<Segment> m_segments;
-  std::map<geometry::PointWithAltitude, std::vector<Segment>> m_beginToSegment;
-  std::map<geometry::PointWithAltitude, std::vector<Segment>> m_endToSegment;
+  std::map<geometry::PointWithAltitude, SegmentListT> m_beginToSegment;
+  std::map<geometry::PointWithAltitude, SegmentListT> m_endToSegment;
 };
 }  // namespace routing

--- a/routing/joint_segment.hpp
+++ b/routing/joint_segment.hpp
@@ -51,6 +51,7 @@ private:
 class JointEdge
 {
 public:
+  JointEdge() = default;    // needed for buffer_vector only
   JointEdge(JointSegment const & target, RouteWeight const & weight)
     : m_target(target), m_weight(weight) {}
 

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -17,13 +17,13 @@ LeapsGraph::LeapsGraph(IndexGraphStarter & starter, MwmHierarchyHandler && hiera
 }
 
 void LeapsGraph::GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                                      std::vector<SegmentEdge> & edges)
+                                      EdgeListT & edges)
 {
   GetEdgesList(vertexData.m_vertex, true /* isOutgoing */, edges);
 }
 
 void LeapsGraph::GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                                     std::vector<SegmentEdge> & edges)
+                                     EdgeListT & edges)
 {
   GetEdgesList(vertexData.m_vertex, false /* isOutgoing */, edges);
 }
@@ -37,7 +37,7 @@ RouteWeight LeapsGraph::HeuristicCostEstimate(Segment const & from, Segment cons
 }
 
 void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
-                              std::vector<SegmentEdge> & edges)
+                              EdgeListT & edges)
 {
   edges.clear();
 
@@ -78,7 +78,7 @@ void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
     crossMwmGraph.GetIngoingEdgeList(segment, edges);
 }
 
-void LeapsGraph::GetEdgesListFromStart(Segment const & segment, std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListFromStart(Segment const & segment, EdgeListT & edges)
 {
   for (auto const mwmId : m_starter.GetStartEnding().m_mwmIds)
   {
@@ -94,7 +94,7 @@ void LeapsGraph::GetEdgesListFromStart(Segment const & segment, std::vector<Segm
   }
 }
 
-void LeapsGraph::GetEdgesListToFinish(Segment const & segment, std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListToFinish(Segment const & segment, EdgeListT & edges)
 {
   for (auto const mwmId : m_starter.GetFinishEnding().m_mwmIds)
   {

--- a/routing/leaps_graph.hpp
+++ b/routing/leaps_graph.hpp
@@ -21,9 +21,9 @@ public:
   // AStarGraph overrides:
   // @{
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                            std::vector<SegmentEdge> & edges) override;
+                            EdgeListT & edges) override;
   void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                           std::vector<SegmentEdge> & edges) override;
+                           EdgeListT & edges) override;
   RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
   RouteWeight GetAStarWeightEpsilon() override;
   // @}
@@ -33,10 +33,10 @@ public:
   ms::LatLon const & GetPoint(Segment const & segment, bool front) const;
 
 private:
-  void GetEdgesList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
+  void GetEdgesList(Segment const & segment, bool isOutgoing, EdgeListT & edges);
 
-  void GetEdgesListFromStart(Segment const & segment, std::vector<SegmentEdge> & edges);
-  void GetEdgesListToFinish(Segment const & segment, std::vector<SegmentEdge> & edges);
+  void GetEdgesListFromStart(Segment const & segment, EdgeListT & edges);
+  void GetEdgesListToFinish(Segment const & segment, EdgeListT & edges);
 
   ms::LatLon m_startPoint;
   ms::LatLon m_finishPoint;

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -33,7 +33,7 @@ bool PedestrianDirectionsEngine::Generate(IndexRoadGraph const & graph,
   streetNames.clear();
   segments.clear();
 
-  vector<Edge> routeEdges;
+  IndexRoadGraph::EdgeVector routeEdges;
 
   CHECK_NOT_EQUAL(m_vehicleType, VehicleType::Count, (m_vehicleType));
 

--- a/routing/regions_sparse_graph.cpp
+++ b/routing/regions_sparse_graph.cpp
@@ -84,7 +84,7 @@ double GetWeight(CrossBorderSegment const & toSeg, LatLonWithAltitude const & co
 }
 
 void RegionsSparseGraph::GetEdgeList(Segment const & segment, bool isOutgoing,
-                                     std::vector<SegmentEdge> & edges,
+                                     EdgeListT & edges,
                                      ms::LatLon const & prevSegFront) const
 {
   auto const & data = GetDataById(segment.GetFeatureId());

--- a/routing/regions_sparse_graph.hpp
+++ b/routing/regions_sparse_graph.hpp
@@ -5,6 +5,8 @@
 #include "routing/latlon_with_altitude.hpp"
 #include "routing/segment.hpp"
 
+#include "routing/base/small_list.hpp"
+
 #include "routing_common/num_mwm_id.hpp"
 
 #include "indexer/data_source.hpp"
@@ -36,7 +38,8 @@ public:
 
   std::optional<FakeEnding> GetFakeEnding(m2::PointD const & point) const;
 
-  void GetEdgeList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges,
+  using EdgeListT = SmallList<SegmentEdge>;
+  void GetEdgeList(Segment const & segment, bool isOutgoing, EdgeListT & edges,
                    ms::LatLon const & prevSegFront) const;
 
   routing::LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;

--- a/routing/road_graph.cpp
+++ b/routing/road_graph.cpp
@@ -194,35 +194,35 @@ void IRoadGraph::CrossIngoingLoader::LoadEdges(FeatureID const & featureId,
 
 // IRoadGraph ------------------------------------------------------------------
 void IRoadGraph::GetOutgoingEdges(geometry::PointWithAltitude const & junction,
-                                  EdgeVector & edges) const
+                                  EdgeListT & edges) const
 {
   GetFakeOutgoingEdges(junction, edges);
   GetRegularOutgoingEdges(junction, edges);
 }
 
 void IRoadGraph::GetIngoingEdges(geometry::PointWithAltitude const & junction,
-                                 EdgeVector & edges) const
+                                 EdgeListT & edges) const
 {
   GetFakeIngoingEdges(junction, edges);
   GetRegularIngoingEdges(junction, edges);
 }
 
 void IRoadGraph::GetRegularOutgoingEdges(geometry::PointWithAltitude const & junction,
-                                         EdgeVector & edges) const
+                                         EdgeListT & edges) const
 {
   CrossOutgoingLoader loader(junction, GetMode(), edges);
   ForEachFeatureClosestToCross(junction.GetPoint(), loader);
 }
 
 void IRoadGraph::GetRegularIngoingEdges(geometry::PointWithAltitude const & junction,
-                                        EdgeVector & edges) const
+                                        EdgeListT & edges) const
 {
   CrossIngoingLoader loader(junction, GetMode(), edges);
   ForEachFeatureClosestToCross(junction.GetPoint(), loader);
 }
 
 void IRoadGraph::GetFakeOutgoingEdges(geometry::PointWithAltitude const & junction,
-                                      EdgeVector & edges) const
+                                      EdgeListT & edges) const
 {
   auto const it = m_fakeOutgoingEdges.find(junction);
   if (it != m_fakeOutgoingEdges.cend())
@@ -230,7 +230,7 @@ void IRoadGraph::GetFakeOutgoingEdges(geometry::PointWithAltitude const & juncti
 }
 
 void IRoadGraph::GetFakeIngoingEdges(geometry::PointWithAltitude const & junction,
-                                     EdgeVector & edges) const
+                                     EdgeListT & edges) const
 {
   auto const it = m_fakeIngoingEdges.find(junction);
   if (it != m_fakeIngoingEdges.cend())
@@ -243,8 +243,7 @@ void IRoadGraph::ResetFakes()
   m_fakeIngoingEdges.clear();
 }
 
-void IRoadGraph::AddEdge(geometry::PointWithAltitude const & j, Edge const & e,
-                         map<geometry::PointWithAltitude, EdgeVector> & edges)
+void IRoadGraph::AddEdge(geometry::PointWithAltitude const & j, Edge const & e, EdgeCacheT & edges)
 {
   auto & cont = edges[j];
   ASSERT(is_sorted(cont.cbegin(), cont.cend()), ());

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -216,7 +216,7 @@ bool CheckGraphConnectivity(Segment const & start, bool isOutgoing, bool useRout
 
   marked.insert(start);
 
-  std::vector<SegmentEdge> edges;
+  WorldGraph::SegmentEdgeListT edges;
   while (!q.empty() && marked.size() < limit)
   {
     auto const u = q.front();

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -41,9 +41,12 @@ template <typename CrossMwmId>
 void TestOutgoingEdges(CrossMwmConnector<CrossMwmId> const & connector, Segment const & from,
                        vector<SegmentEdge> const & expectedEdges)
 {
-  vector<SegmentEdge> edges;
+  typename CrossMwmConnector<CrossMwmId>::EdgeListT edges;
   connector.GetOutgoingEdgeList(from, edges);
-  TEST_EQUAL(edges, expectedEdges, ());
+
+  TEST_EQUAL(edges.size(), expectedEdges.size(), ());
+  for (size_t i = 0; i < edges.size(); ++i)
+    TEST_EQUAL(edges[i], expectedEdges[i], ());
 }
 
 template <typename CrossMwmId>

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -84,7 +84,7 @@ void TestEdges(IndexGraph & graph, Segment const & segment, vector<Segment> cons
   ASSERT(segment.IsForward() || !graph.GetGeometry().GetRoad(segment.GetFeatureId()).IsOneWay(),
          ());
 
-  vector<SegmentEdge> edges;
+  IndexGraph::SegmentEdgeListT edges;
   graph.GetEdgeList(segment, isOutgoing, true /* useRoutingOptions */, edges);
 
   vector<Segment> targets;

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -62,7 +62,7 @@ public:
   }
 
   void GetOutgoingEdgesList(astar::VertexData<Vertex, RouteWeight> const & vertexData,
-                            std::vector<Edge> & edges) override
+                            EdgeListT & edges) override
   {
     edges.clear();
     m_graph->GetEdgeList(vertexData, true /* isOutgoing */, true /* useRoutingOptions */,
@@ -70,7 +70,7 @@ public:
   }
 
   void GetIngoingEdgesList(astar::VertexData<Vertex, RouteWeight> const & vertexData,
-                           std::vector<Edge> & edges) override
+                           EdgeListT & edges) override
   {
     edges.clear();
     m_graph->GetEdgeList(vertexData, false /* isOutgoing */, true /* useRoutingOptions */,

--- a/routing/routing_tests/road_graph_nearest_edges_test.cpp
+++ b/routing/routing_tests/road_graph_nearest_edges_test.cpp
@@ -61,7 +61,7 @@ UNIT_TEST(RoadGraph_NearestEdges)
       geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0));
 
   // Expected outgoing edges.
-  IRoadGraph::EdgeVector expectedOutgoing = {
+  IRoadGraph::EdgeListT expectedOutgoing = {
       Edge::MakeReal(MakeTestFeatureID(0) /* first road */, false /* forward */, 1 /* segId */,
                      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0)),
                      geometry::MakePointWithAltitudeForTesting(m2::PointD(-1, 0))),
@@ -78,7 +78,7 @@ UNIT_TEST(RoadGraph_NearestEdges)
   sort(expectedOutgoing.begin(), expectedOutgoing.end());
 
   // Expected ingoing edges.
-  IRoadGraph::EdgeVector expectedIngoing = {
+  IRoadGraph::EdgeListT expectedIngoing = {
       Edge::MakeReal(MakeTestFeatureID(0) /* first road */, true /* forward */, 1 /* segId */,
                      geometry::MakePointWithAltitudeForTesting(m2::PointD(-1, 0)),
                      geometry::MakePointWithAltitudeForTesting(m2::PointD(0, 0))),
@@ -95,16 +95,22 @@ UNIT_TEST(RoadGraph_NearestEdges)
   sort(expectedIngoing.begin(), expectedIngoing.end());
 
   // Check outgoing edges.
-  IRoadGraph::EdgeVector actualOutgoing;
+  IRoadGraph::EdgeListT actualOutgoing;
   graph.GetOutgoingEdges(crossPos, actualOutgoing);
   sort(actualOutgoing.begin(), actualOutgoing.end());
-  TEST_EQUAL(expectedOutgoing, actualOutgoing, ());
+
+  TEST_EQUAL(expectedOutgoing.size(), actualOutgoing.size(), ());
+  for (size_t i = 0; i < expectedOutgoing.size(); ++i)
+    TEST_EQUAL(expectedOutgoing[i], actualOutgoing[i], ());
 
   // Check ingoing edges.
-  IRoadGraph::EdgeVector actualIngoing;
+  IRoadGraph::EdgeListT actualIngoing;
   graph.GetIngoingEdges(crossPos, actualIngoing);
   sort(actualIngoing.begin(), actualIngoing.end());
-  TEST_EQUAL(expectedIngoing, actualIngoing, ());
+
+  TEST_EQUAL(expectedOutgoing.size(), actualIngoing.size(), ());
+  for (size_t i = 0; i < expectedOutgoing.size(); ++i)
+    TEST_EQUAL(expectedOutgoing[i], actualIngoing[i], ());
 }
 
 }  // namespace routing_test

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -28,19 +28,19 @@ size_t UndirectedGraph::GetNodesNumber() const
 }
 
 void UndirectedGraph::GetEdgesList(Vertex const & vertex, bool /* isOutgoing */,
-                                   std::vector<Edge> & adj)
+                                   EdgeListT & adj)
 {
   GetAdjacencyList(vertex, adj);
 }
 
 void UndirectedGraph::GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                                          std::vector<SimpleEdge> & adj)
+                                          EdgeListT & adj)
 {
   GetEdgesList(vertexData.m_vertex, false /* isOutgoing */, adj);
 }
 
 void UndirectedGraph::GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                                           std::vector<SimpleEdge> & adj)
+                                           EdgeListT & adj)
 {
   GetEdgesList(vertexData.m_vertex, true /* isOutgoing */, adj);
 }
@@ -50,7 +50,7 @@ double UndirectedGraph::HeuristicCostEstimate(Vertex const & v, Vertex const & w
   return 0.0;
 }
 
-void UndirectedGraph::GetAdjacencyList(Vertex v, std::vector<Edge> & adj) const
+void UndirectedGraph::GetAdjacencyList(Vertex v, EdgeListT & adj) const
 {
   adj.clear();
   auto const it = m_adjs.find(v);
@@ -64,7 +64,7 @@ void DirectedGraph::AddEdge(Vertex from, Vertex to, Weight w)
   m_ingoing[to].emplace_back(from, w);
 }
 
-void DirectedGraph::GetEdgesList(Vertex const & v, bool isOutgoing, std::vector<Edge> & adj)
+void DirectedGraph::GetEdgesList(Vertex const & v, bool isOutgoing, EdgeListT & adj)
 {
   adj = isOutgoing ? m_outgoing[v] : m_ingoing[v];
 }
@@ -93,6 +93,7 @@ inline double TimeBetweenSec(geometry::PointWithAltitude const & j1,
 class WeightedEdge
 {
 public:
+  WeightedEdge() = default;   // needed for buffer_vector only
   WeightedEdge(geometry::PointWithAltitude const & target, double weight)
     : target(target), weight(weight)
   {
@@ -102,8 +103,8 @@ public:
   inline double GetWeight() const { return weight; }
 
 private:
-  geometry::PointWithAltitude const target;
-  double const weight;
+  geometry::PointWithAltitude target;
+  double weight;
 };
 
 using Algorithm = AStarAlgorithm<geometry::PointWithAltitude, WeightedEdge, double>;
@@ -118,10 +119,10 @@ public:
   {}
 
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                            std::vector<Edge> & adj) override
+                            EdgeListT & adj) override
   {
     auto const & v = vertexData.m_vertex;
-    IRoadGraph::EdgeVector edges;
+    IRoadGraph::EdgeListT edges;
     m_roadGraph.GetOutgoingEdges(v, edges);
 
     adj.clear();
@@ -138,10 +139,10 @@ public:
   }
 
   void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                           std::vector<Edge> & adj) override
+                           EdgeListT & adj) override
   {
     auto const & v = vertexData.m_vertex;
-    IRoadGraph::EdgeVector edges;
+    IRoadGraph::EdgeListT edges;
     m_roadGraph.GetIngoingEdges(v, edges);
 
     adj.clear();

--- a/routing/routing_tests/routing_algorithm.hpp
+++ b/routing/routing_tests/routing_algorithm.hpp
@@ -18,6 +18,7 @@ using namespace routing;
 
 struct SimpleEdge
 {
+  SimpleEdge() = default;   // needed for buffer_vector only
   SimpleEdge(uint32_t to, double weight) : m_to(to), m_weight(weight) {}
 
   uint32_t GetTarget() const { return m_to; }
@@ -36,18 +37,18 @@ public:
   // AStarGraph overrides
   // @{
   void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                           std::vector<Edge> & adj) override;
+                           EdgeListT & adj) override;
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
-                            std::vector<Edge> & adj) override;
+                            EdgeListT & adj) override;
   double HeuristicCostEstimate(Vertex const & v, Vertex const & w) override;
   // @}
 
-  void GetEdgesList(Vertex const & vertex, bool /* isOutgoing */, std::vector<Edge> & adj);
+  void GetEdgesList(Vertex const & vertex, bool /* isOutgoing */, EdgeListT & adj);
 
 private:
-  void GetAdjacencyList(Vertex v, std::vector<Edge> & adj) const;
+  void GetAdjacencyList(Vertex v, EdgeListT & adj) const;
 
-  std::map<uint32_t, std::vector<Edge>> m_adjs;
+  std::map<uint32_t, EdgeListT> m_adjs;
 };
 
 class DirectedGraph
@@ -57,13 +58,15 @@ public:
   using Edge = SimpleEdge;
   using Weight = double;
 
+  using EdgeListT = SmallList<SimpleEdge>;
+
   void AddEdge(Vertex from, Vertex to, Weight w);
 
-  void GetEdgesList(Vertex const & v, bool isOutgoing, std::vector<Edge> & adj);
+  void GetEdgesList(Vertex const & v, bool isOutgoing, EdgeListT & adj);
 
 private:
-  std::map<uint32_t, std::vector<Edge>> m_outgoing;
-  std::map<uint32_t, std::vector<Edge>> m_ingoing;
+  std::map<uint32_t, EdgeListT> m_outgoing;
+  std::map<uint32_t, EdgeListT> m_ingoing;
 };
 }  // namespace routing_tests
 

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -33,12 +33,12 @@ SingleVehicleWorldGraph::SingleVehicleWorldGraph(unique_ptr<CrossMwmGraph> cross
 }
 
 void SingleVehicleWorldGraph::CheckAndProcessTransitFeatures(Segment const & parent,
-                                                             vector<JointEdge> & jointEdges,
-                                                             vector<RouteWeight> & parentWeights,
+                                                             JointEdgeListT & jointEdges,
+                                                             WeightListT & parentWeights,
                                                              bool isOutgoing)
 {
   bool opposite = !isOutgoing;
-  vector<JointEdge> newCrossMwmEdges;
+  JointEdgeListT newCrossMwmEdges;
 
   NumMwmId const mwmId = parent.GetMwmId();
 
@@ -65,7 +65,7 @@ void SingleVehicleWorldGraph::CheckAndProcessTransitFeatures(Segment const & par
 
       auto & twinIndexGraph = GetIndexGraph(twinMwmId);
 
-      vector<uint32_t> lastPoints;
+      IndexGraph::PointIdListT lastPoints;
       twinIndexGraph.GetLastPointsForJoint({start}, isOutgoing, lastPoints);
       ASSERT_EQUAL(lastPoints.size(), 1, ());
 
@@ -89,7 +89,7 @@ void SingleVehicleWorldGraph::CheckAndProcessTransitFeatures(Segment const & par
 
 void SingleVehicleWorldGraph::GetEdgeList(
     astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
-    bool useRoutingOptions, bool useAccessConditional, vector<SegmentEdge> & edges)
+    bool useRoutingOptions, bool useAccessConditional, SegmentEdgeListT & edges)
 {
   CHECK_NOT_EQUAL(m_mode, WorldGraphMode::LeapsOnly, ());
 
@@ -106,8 +106,8 @@ void SingleVehicleWorldGraph::GetEdgeList(
 
 void SingleVehicleWorldGraph::GetEdgeList(
     astar::VertexData<JointSegment, RouteWeight> const & parentVertexData, Segment const & parent,
-    bool isOutgoing, bool useAccessConditional, vector<JointEdge> & jointEdges,
-    vector<RouteWeight> & parentWeights)
+    bool isOutgoing, bool useAccessConditional, JointEdgeListT & jointEdges,
+    WeightListT & parentWeights)
 {
   // Fake segments aren't processed here. All work must be done
   // on the IndexGraphStarterJoints abstraction-level.

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -41,12 +41,12 @@ public:
 
   void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
                    bool useRoutingOptions, bool useAccessConditional,
-                   std::vector<SegmentEdge> & edges) override;
+                   SegmentEdgeListT & edges) override;
 
   void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                    Segment const & parent, bool isOutgoing, bool useAccessConditional,
-                   std::vector<JointEdge> & jointEdges,
-                   std::vector<RouteWeight> & parentWeights) override;
+                   JointEdgeListT & jointEdges,
+                   WeightListT & parentWeights) override;
 
   bool CheckLength(RouteWeight const &, double) const override { return true; }
 
@@ -118,8 +118,8 @@ private:
   // Retrieves the same |jointEdges|, but into others mwms.
   // If they are cross mwm edges, of course.
   void CheckAndProcessTransitFeatures(Segment const & parent,
-                                      std::vector<JointEdge> & jointEdges,
-                                      std::vector<RouteWeight> & parentWeights,
+                                      JointEdgeListT & jointEdges,
+                                      WeightListT & parentWeights,
                                       bool isOutgoing);
   // WorldGraph overrides:
   void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;

--- a/routing/transit_graph.cpp
+++ b/routing/transit_graph.cpp
@@ -180,7 +180,7 @@ RouteWeight TransitGraph::GetTransferPenalty(Segment const & from, Segment const
 }
 
 void TransitGraph::GetTransitEdges(Segment const & segment, bool isOutgoing,
-                                   vector<SegmentEdge> & edges) const
+                                   EdgeListT & edges) const
 {
   CHECK(IsTransitSegment(segment), ("Nontransit segment passed to TransitGraph."));
   for (auto const & s : m_fake.GetEdges(segment, isOutgoing))

--- a/routing/transit_graph.hpp
+++ b/routing/transit_graph.hpp
@@ -46,8 +46,10 @@ public:
   LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) const;
   RouteWeight GetTransferPenalty(Segment const & from, Segment const & to) const;
+
+  using EdgeListT = SmallList<SegmentEdge>;
   void GetTransitEdges(Segment const & segment, bool isOutgoing,
-                       std::vector<SegmentEdge> & edges) const;
+                       EdgeListT & edges) const;
   std::set<Segment> const & GetFake(Segment const & real) const;
   bool FindReal(Segment const & fake, Segment & real) const;
 

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -26,7 +26,7 @@ TransitWorldGraph::TransitWorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
 
 void TransitWorldGraph::GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData,
                                     bool isOutgoing, bool useRoutingOptions,
-                                    bool useAccessConditional, vector<SegmentEdge> & edges)
+                                    bool useAccessConditional, SegmentEdgeListT & edges)
 {
   auto const & segment = vertexData.m_vertex;
   auto & transitGraph = GetTransitGraph(segment.GetMwmId());
@@ -54,7 +54,7 @@ void TransitWorldGraph::GetEdgeList(astar::VertexData<Segment, RouteWeight> cons
     AddRealEdges(vertexData, isOutgoing, useRoutingOptions, edges);
   }
 
-  vector<SegmentEdge> fakeFromReal;
+  SegmentEdgeListT fakeFromReal;
   for (auto const & edge : edges)
   {
     auto const & edgeSegment = edge.GetTarget();
@@ -71,8 +71,8 @@ void TransitWorldGraph::GetEdgeList(astar::VertexData<Segment, RouteWeight> cons
 
 void TransitWorldGraph::GetEdgeList(
     astar::VertexData<JointSegment, RouteWeight> const & parentVertexData, Segment const & segment,
-    bool isOutgoing, bool useAccessConditional, std::vector<JointEdge> & edges,
-    std::vector<RouteWeight> & parentWeights)
+    bool isOutgoing, bool useAccessConditional, JointEdgeListT & edges,
+    WeightListT & parentWeights)
 {
   CHECK(false, ("TransitWorldGraph does not support Joints mode."));
 }
@@ -222,7 +222,7 @@ RoadGeometry const & TransitWorldGraph::GetRealRoadGeometry(NumMwmId mwmId, uint
 
 void TransitWorldGraph::AddRealEdges(astar::VertexData<Segment, RouteWeight> const & vertexData,
                                      bool isOutgoing, bool useRoutingOptions,
-                                     vector<SegmentEdge> & edges)
+                                     SegmentEdgeListT & edges)
 {
   auto const & segment = vertexData.m_vertex;
   auto & indexGraph = GetIndexGraph(segment.GetMwmId());

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -39,12 +39,12 @@ public:
 
   void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
                    bool useRoutingOptions, bool useAccessConditional,
-                   std::vector<SegmentEdge> & edges) override;
+                   SegmentEdgeListT & edges) override;
   // Dummy method which shouldn't be called.
   void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                    Segment const & segment, bool isOutgoing, bool useAccessConditional,
-                   std::vector<JointEdge> & edges,
-                   std::vector<RouteWeight> & parentWeights) override;
+                   JointEdgeListT & edges,
+                   WeightListT & parentWeights) override;
 
   bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const override
   {
@@ -90,7 +90,7 @@ private:
 
   RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
   void AddRealEdges(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
-                    bool useRoutingOptions, std::vector<SegmentEdge> & edges);
+                    bool useRoutingOptions, SegmentEdgeListT & edges);
   TransitGraph & GetTransitGraph(NumMwmId mwmId);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -5,14 +5,14 @@
 namespace routing
 {
 void WorldGraph::GetEdgeList(Segment const & vertex, bool isOutgoing, bool useRoutingOptions,
-                             std::vector<SegmentEdge> & edges)
+                             SegmentEdgeListT & edges)
 {
   GetEdgeList({vertex, RouteWeight(0.0)}, isOutgoing, useRoutingOptions,
               false /* useAccessConditional */, edges);
 }
 
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
-                          std::vector<SegmentEdge> & edges)
+                          SegmentEdgeListT & edges)
 {
   std::vector<Segment> twins;
   GetTwinsInner(segment, isOutgoing, twins);

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -48,22 +48,26 @@ public:
   template <typename VertexType>
   using Parents = IndexGraph::Parents<VertexType>;
 
+  using JointEdgeListT = IndexGraph::JointEdgeListT;
+  using SegmentEdgeListT = IndexGraph::SegmentEdgeListT;
+  using WeightListT = IndexGraph::WeightListT;
+
   virtual ~WorldGraph() = default;
 
   virtual void GetEdgeList(astar::VertexData<Segment, RouteWeight> const & vertexData,
                            bool isOutgoing, bool useRoutingOptions, bool useAccessConditional,
-                           std::vector<SegmentEdge> & edges) = 0;
+                           SegmentEdgeListT & edges) = 0;
   virtual void GetEdgeList(astar::VertexData<JointSegment, RouteWeight> const & vertexData,
                            Segment const & segment, bool isOutgoing, bool useAccessConditional,
-                           std::vector<JointEdge> & edges,
-                           std::vector<RouteWeight> & parentWeights) = 0;
+                           JointEdgeListT & edges,
+                           WeightListT & parentWeights) = 0;
 
   bool IsRegionsGraphMode() const { return m_isRegionsGraphMode; }
 
   void SetRegionsGraphMode(bool isRegionsGraphMode) { m_isRegionsGraphMode = isRegionsGraphMode; }
 
   void GetEdgeList(Segment const & vertex, bool isOutgoing, bool useRoutingOptions,
-                   std::vector<SegmentEdge> & edges);
+                   SegmentEdgeListT & edges);
 
   // Checks whether path length meets restrictions. Restrictions may depend on the distance from
   // start to finish of the route.
@@ -124,7 +128,7 @@ public:
 
 protected:
   void GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
-                std::vector<SegmentEdge> & edges);
+                SegmentEdgeListT & edges);
 
   bool m_isRegionsGraphMode = false;
 };

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -39,7 +39,7 @@ double DistanceToSegment(Segment const & segment, m2::PointD const & point, Inde
       mercator::FromLatLon(indexGraph.GetGeometry().GetPoint(segment.GetRoadPoint(true))), point);
 }
 
-bool EdgesContain(vector<SegmentEdge> const & edges, Segment const & segment)
+bool EdgesContain(IndexGraph::SegmentEdgeListT const & edges, Segment const & segment)
 {
   for (auto const & edge : edges)
   {
@@ -177,7 +177,7 @@ void TrackMatcher::Step::FillCandidatesWithNearbySegments(
 
 void TrackMatcher::Step::FillCandidates(Step const & previousStep, IndexGraph & graph)
 {
-  vector<SegmentEdge> edges;
+  IndexGraph::SegmentEdgeListT edges;
 
   for (Candidate const & candidate : previousStep.m_candidates)
   {
@@ -210,7 +210,7 @@ void TrackMatcher::Step::ChooseSegment(Step const & nextStep, IndexGraph & index
 
   double minDistance = numeric_limits<double>::max();
 
-  vector<SegmentEdge> edges;
+  IndexGraph::SegmentEdgeListT edges;
   indexGraph.GetEdgeList(nextStep.m_segment, false /* isOutgoing */, true /* useRoutingOptions */,
                          edges);
   edges.emplace_back(nextStep.m_segment, GetAStarWeightZero<RouteWeight>());


### PR DESCRIPTION
Main purpose here is to avoid small std::vector in frequent GetEdgeList.
Checked that average edges count from node is 2, so use ``` buffer_vector<T, 8> ```