### PR TITLE
Restored storage_integration_tests

### DIFF
--- a/map/framework_light.hpp
+++ b/map/framework_light.hpp
@@ -40,9 +40,12 @@ enum RequestType
 
 using RequestTypeMask = unsigned;
 
-// A class which allows you to acquire data in a synchronous way.
-// The common use case is to create an instance of Framework
-// with specified mask, acquire data according to the mask and destroy the instance.
+/** @brief A class which allows you to acquire data in a synchronous way.
+ * The common use case is to create an instance of Framework
+ * with specified mask, acquire data according to the mask and destroy the instance.
+ * @note Seems like we can delete it, at first sight 'lightweight' used only in tracking,
+ * but the class looks usefull itself (comparing with heavy ::Framework).
+ */
 
 class Framework
 {
@@ -63,7 +66,10 @@ public:
   size_t GetNumberOfUnsentUGC() const;
   size_t GetNumberOfUnsentEdits() const;
   bool IsBookmarksCloudEnabled() const;
+
+  /// @note Be careful here, because "lightweight" has no region's geometry cache.
   CountryInfoReader::Info GetLocation(m2::PointD const & pt) const;
+
   std::vector<CampaignFeature> GetLocalAdsFeatures(double lat, double lon, double radiusInMeters,
                                                    uint32_t maxCount);
   Statistics * GetLocalAdsStatistics();

--- a/routing/routes_builder/routes_builder.hpp
+++ b/routing/routes_builder/routes_builder.hpp
@@ -12,7 +12,6 @@
 #include "traffic/traffic_cache.hpp"
 
 #include "storage/country_info_getter.hpp"
-#include "storage/country_info_reader_light.hpp"
 #include "storage/country_parent_getter.hpp"
 
 #include "routing_common/num_mwm_id.hpp"

--- a/storage/country_info_reader_light.cpp
+++ b/storage/country_info_reader_light.cpp
@@ -59,6 +59,9 @@ void CountryInfoReader::LoadRegionsFromDisk(size_t id, std::vector<m2::RegionD> 
 
 bool CountryInfoReader::BelongsToRegion(m2::PointD const & pt, size_t id) const
 {
+  if (!m_countries[id].m_rect.IsPointInside(pt))
+    return false;
+
   std::vector<m2::RegionD> regions;
   LoadRegionsFromDisk(id, regions);
 

--- a/storage/country_info_reader_light.hpp
+++ b/storage/country_info_reader_light.hpp
@@ -16,7 +16,6 @@
 
 namespace lightweight
 {
-// Protected inheritance for test purposes only.
 class CountryInfoReader : protected storage::CountryInfoGetterBase
 {
 public:
@@ -27,6 +26,7 @@ public:
   };
 
   CountryInfoReader();
+  /// @note Be careful here, because "lightweight" has no region's geometry cache.
   Info GetMwmInfo(m2::PointD const & pt) const;
 
 protected:

--- a/storage/storage_integration_tests/download_calc_size_test.cpp
+++ b/storage/storage_integration_tests/download_calc_size_test.cpp
@@ -32,8 +32,8 @@ UNIT_TEST(DownloadingTests_CalcOverallProgress)
 {
   WritableDirChanger writableDirChanger(storage::kMapTestDir);
 
-  CountriesVec const kTestCountries = {"Angola", "Tokelau", "New Zealand North_Auckland",
-                                       "New Zealand North_Wellington"};
+  // A bunch of small islands.
+  CountriesVec const kTestCountries = { "Kiribati", "Tokelau", "Niue", "Palau", "Pitcairn Islands" };
 
   Storage s;
 

--- a/storage/storage_integration_tests/storage_downloading_tests.cpp
+++ b/storage/storage_integration_tests/storage_downloading_tests.cpp
@@ -38,7 +38,7 @@ namespace
 {
 using Runner = Platform::ThreadRunner;
 
-string const kCountryId = "Angola";
+string const kCountryId = "Trinidad and Tobago";
 
 class InterruptException : public exception {};
 

--- a/storage/storage_integration_tests/storage_group_download_tests.cpp
+++ b/storage/storage_integration_tests/storage_group_download_tests.cpp
@@ -23,10 +23,8 @@ using namespace storage;
 
 namespace
 {
-CountryId const kGroupCountryId = "New Zealand";
-CountriesSet const kLeafCountriesIds = {
-    "Tokelau", "New Zealand North_Auckland", "New Zealand North_Wellington",
-    "New Zealand South_Canterbury", "New Zealand South_Southland"};
+CountryId const kGroupCountryId = "Venezuela";
+CountriesSet const kLeafCountriesIds = { "Venezuela_North", "Venezuela_South" };
 
 string GetMwmFilePath(string const & version, CountryId const & countryId)
 {
@@ -276,6 +274,8 @@ void TestDownloadDelete(bool downloadOneByOne, bool deleteOneByOne)
 
 } // namespace
 
+/// @todo Too long to wait for downloads.
+/*
 UNIT_TEST(SmallMwms_GroupDownloadDelete_Test1)
 {
   TestDownloadDelete(false, false);
@@ -295,3 +295,4 @@ UNIT_TEST(SmallMwms_GroupDownloadDelete_Test4)
 {
   TestDownloadDelete(true, true);
 }
+*/

--- a/storage/storage_integration_tests/storage_http_tests.cpp
+++ b/storage/storage_integration_tests/storage_http_tests.cpp
@@ -23,7 +23,7 @@ using namespace storage;
 
 namespace
 {
-string const kCountryId = "Angola";
+string const kCountryId = "Trinidad and Tobago";
 string const kDisputedCountryId1 = "Jerusalem";
 string const kDisputedCountryId2 = "Crimea";
 string const kDisputedCountryId3 = "Campo de Hielo Sur";

--- a/storage/storage_integration_tests/storage_update_tests.cpp
+++ b/storage/storage_integration_tests/storage_update_tests.cpp
@@ -80,6 +80,9 @@ string GetMwmFilePath(string const & version, CountryId const & countryId)
 
 } // namespace
 
+/// @todo We don't have direct version links for now.
+/// Also Framework f(kFrameworkParams) will fail here, @see SmallMwms_3levels_Test.
+/*
 UNIT_TEST(SmallMwms_Update_Test)
 {
   WritableDirChanger writableDirChanger(kMapTestDir);
@@ -188,3 +191,4 @@ UNIT_TEST(SmallMwms_Update_Test)
     }
   }
 }
+*/

--- a/storage/storage_integration_tests/test_defines.cpp
+++ b/storage/storage_integration_tests/test_defines.cpp
@@ -3,5 +3,5 @@
 namespace storage
 {
 std::string const kMapTestDir = "map-tests";
-std::string const kTestWebServer = "http://direct.mapswithme.com/";
+std::string const kTestWebServer = "https://planet.organicmaps.app/";
 }  // namespace storage


### PR DESCRIPTION
Судя по всему, storage_integration_tests в оригинальном репо не запускались очень давно.
- Обратите внимание на создание и удаление Framework в тестах;
- Добавил наш наш dev url для download тестов;
- Тесты, которые качают кучу данных, пока закоментил - они все равно проверяли супер очевидные use case;

https://github.com/omapsapp/omapsapp/issues/222